### PR TITLE
:ambulance: Remove sync methods blocking main thread on Unity

### DIFF
--- a/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
@@ -9,6 +9,7 @@ using Solana.Unity.Wallet;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -21,7 +22,7 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
@@ -32,12 +33,12 @@ namespace Solana.Unity.Examples
             #region Create and Initialize a token Mint Account
 
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = RpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionAcc =
-                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             ulong minBalanceForExemptionMint =
-                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
 
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
@@ -81,7 +82,7 @@ namespace Solana.Unity.Examples
                 AddInstruction(MemoProgram.NewMemo(initialAccount, "Hello from Sol.Net")).
                 Build(new List<Account> { ownerAccount, mintAccount, initialAccount });
 
-            string createAndInitializeMintToTxSignature = Examples.SubmitTxSendAndLog(createAndInitializeMintToTx);
+            string createAndInitializeMintToTxSignature = await Examples.SubmitTxSendAndLog(createAndInitializeMintToTx);
 
             Examples.PollConfirmedTx(createAndInitializeMintToTxSignature);
 
@@ -117,7 +118,7 @@ namespace Solana.Unity.Examples
                 AddInstruction(MemoProgram.NewMemo(ownerAccount, "Hello from Sol.Net")).
                 Build(new List<Account> { ownerAccount });
 
-            string createAssociatedTokenAccountTxSignature = Examples.SubmitTxSendAndLog(createAssociatedTokenAccountTx);
+            string createAssociatedTokenAccountTxSignature = await Examples.SubmitTxSendAndLog(createAssociatedTokenAccountTx);
 
             Examples.PollConfirmedTx(createAssociatedTokenAccountTxSignature);
 

--- a/src/Solana.Unity.Examples/ExampleHelpers.cs
+++ b/src/Solana.Unity.Examples/ExampleHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -26,15 +27,15 @@ namespace Solana.Unity.Examples
         /// Submits a transaction and logs the output from SimulateTransaction.
         /// </summary>
         /// <param name="tx">The transaction data ready to simulate or submit to the network.</param>
-        public static string SubmitTxSendAndLog(byte[] tx)
+        public static async Task<string> SubmitTxSendAndLog(byte[] tx)
         {
             Console.WriteLine($"Tx Data: {Convert.ToBase64String(tx)}");
 
-            RequestResult<ResponseValue<SimulationLogs>> txSim = RpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await RpcClient.SimulateTransactionAsync(tx);
             string logs = PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = RpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await RpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
 
             return txReq.Result;
@@ -44,13 +45,13 @@ namespace Solana.Unity.Examples
         /// Polls the rpc client until a transaction signature has been confirmed.
         /// </summary>
         /// <param name="signature">The first transaction signature.</param>
-        public static void PollConfirmedTx(string signature)
+        public static async void PollConfirmedTx(string signature)
         {
-            RequestResult<TransactionMetaSlotInfo> txMeta = RpcClient.GetTransaction(signature);
+            RequestResult<TransactionMetaSlotInfo> txMeta = await RpcClient.GetTransactionAsync(signature);
             while (!txMeta.WasSuccessful)
             {
                 Thread.Sleep(5000);
-                txMeta = RpcClient.GetTransaction(signature);
+                txMeta = await RpcClient.GetTransactionAsync(signature);
             }
         }
 

--- a/src/Solana.Unity.Examples/GetTokenAccountsByOwnerExample.cs
+++ b/src/Solana.Unity.Examples/GetTokenAccountsByOwnerExample.cs
@@ -5,6 +5,7 @@ using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -20,11 +21,11 @@ namespace Solana.Unity.Examples
         {
         }
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
             Account ownerAccount = wallet.GetAccount(10);
-            RequestResult<ResponseValue<List<TokenAccount>>> token_accounts = rpcClient.GetTokenAccountsByOwner(ownerAccount.PublicKey, tokenProgramId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+            RequestResult<ResponseValue<List<TokenAccount>>> token_accounts = await rpcClient.GetTokenAccountsByOwnerAsync(ownerAccount.PublicKey, tokenProgramId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
             foreach (TokenAccount account in token_accounts.Result.Value)
             {
@@ -33,7 +34,7 @@ namespace Solana.Unity.Examples
             }
 
             var tokAccount = new PublicKey("CuieVDEDtLo7FypA9SbLM9saXFdb1dsshEkyErMqkRQq");
-            var tokenAccounts = mRpcClient.GetTokenAccountsByOwner(tokAccount, tokenProgramId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+            var tokenAccounts = await mRpcClient.GetTokenAccountsByOwnerAsync(tokAccount, tokenProgramId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
             foreach (TokenAccount account in tokenAccounts.Result.Value)
             {
@@ -44,7 +45,7 @@ namespace Solana.Unity.Examples
             }
 
             var delegateKey = new PublicKey("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T");
-            var delegateTokenAccounts = mRpcClient.GetTokenAccountsByDelegate(delegateKey, "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT");
+            var delegateTokenAccounts = await mRpcClient.GetTokenAccountsByDelegateAsync(delegateKey, "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT");
 
             foreach (TokenAccount account in delegateTokenAccounts.Result.Value)
             {

--- a/src/Solana.Unity.Examples/IExample.cs
+++ b/src/Solana.Unity.Examples/IExample.cs
@@ -1,4 +1,6 @@
-﻿namespace Solana.Unity.Examples
+﻿using System.Threading.Tasks;
+
+namespace Solana.Unity.Examples
 {
     interface IExample
     {

--- a/src/Solana.Unity.Examples/InstructionDecoderExample.cs
+++ b/src/Solana.Unity.Examples/InstructionDecoderExample.cs
@@ -5,6 +5,7 @@ using Solana.Unity.Rpc.Models;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -16,14 +17,14 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(MnemonicWords);
 
             var fromAccount = wallet.GetAccount(10);
             var toAccount = wallet.GetAccount(8);
 
-            var blockHash = rpcClient.GetRecentBlockHash();
+            var blockHash = await rpcClient.GetRecentBlockHashAsync();
             Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
 
             var msgBytes = new TransactionBuilder()
@@ -57,12 +58,12 @@ namespace Solana.Unity.Examples
     public class InstructionDecoderFromBlockExample : IExample
     {
         private static readonly IRpcClient rpcClient = ClientFactory.GetClient(Cluster.TestNet);
-        public void Run()
+        public async void Run()
         {
             var blockList = new ulong[] { 87731252, 87731314 };
             foreach (var slot in blockList)
             {
-                var block = rpcClient.GetBlock(slot);
+                var block = await rpcClient.GetBlockAsync(slot);
                 File.WriteAllText($"./response{slot}.json", block.RawRpcResponse);
                 Console.WriteLine($"BlockHash >> {block.Result.Blockhash}");
 

--- a/src/Solana.Unity.Examples/MultisigExamples.cs
+++ b/src/Solana.Unity.Examples/MultisigExamples.cs
@@ -8,6 +8,7 @@ using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -22,20 +23,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -88,10 +89,10 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string createMultiSigAndMintSignature = Examples.SubmitTxSendAndLog(txBytes);
+            string createMultiSigAndMintSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(createMultiSigAndMintSignature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -134,7 +135,7 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string mintToSignature = Examples.SubmitTxSendAndLog(txBytes);
+            string mintToSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(mintToSignature);
         }
     }
@@ -150,20 +151,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -207,7 +208,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string mintToSignature = Examples.SubmitTxSendAndLog(txBytes);
+            string mintToSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(mintToSignature);
         }
     }
@@ -223,20 +224,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -306,7 +307,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string signature = Examples.SubmitTxSendAndLog(txBytes);
+            string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
             // After the previous transaction is confirmed we use TransferChecked to transfer tokens using the
@@ -339,7 +340,7 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
         }
     }
@@ -355,20 +356,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -424,10 +425,10 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string signature = Examples.SubmitTxSendAndLog(txBytes);
+            string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
 
             // Then we create an account which will be the token's mint authority
@@ -476,10 +477,10 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             // Here we mint tokens to an account using the mint authority multi sig
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
@@ -523,10 +524,10 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             // After doing this, we freeze the account to which we just minted tokens
             // Notice how the signers used are different, because the `freezeAuthority` has different signers
@@ -560,10 +561,10 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             // Because we're actually cool people, we now thaw that same account and then set the authority to nothing
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
@@ -607,7 +608,7 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
         }
     }
@@ -623,20 +624,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -700,10 +701,10 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string signature = Examples.SubmitTxSendAndLog(txBytes);
+            string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -746,10 +747,10 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -783,10 +784,10 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = rpcClient.GetRecentBlockHash();
+            blockHash = await rpcClient.GetRecentBlockHashAsync();
 
 
             msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
@@ -824,7 +825,7 @@ namespace Solana.Unity.Examples
 
             txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            signature = Examples.SubmitTxSendAndLog(txBytes);
+            signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
         }
@@ -841,20 +842,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -925,7 +926,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string signature = Examples.SubmitTxSendAndLog(txBytes);
+            string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
         }
@@ -942,20 +943,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -970,7 +971,7 @@ namespace Solana.Unity.Examples
 
             // The account has balance so we'll burn it before
             RequestResult<ResponseValue<TokenBalance>> balance =
-                rpcClient.GetTokenAccountBalance(tokenAccountWithMultisigOwner.PublicKey);
+                await rpcClient.GetTokenAccountBalanceAsync(tokenAccountWithMultisigOwner.PublicKey);
 
             Console.WriteLine($"Account Balance >> {balance.Result.Value.UiAmountString}");
 
@@ -1016,7 +1017,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string signature = Examples.SubmitTxSendAndLog(txBytes);
+            string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
         }
@@ -1031,14 +1032,14 @@ namespace Solana.Unity.Examples
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
             // The multisig which is the token account authority
             Account tokenMultiSignature = wallet.GetAccount(4045);
 
-            var account = rpcClient.GetAccountInfo(tokenMultiSignature.PublicKey);
+            var account = await rpcClient.GetAccountInfoAsync(tokenMultiSignature.PublicKey);
 
             var multiSigAccount = MultiSignatureAccount.Deserialize(Convert.FromBase64String(account.Result.Value.Data[0]));
 

--- a/src/Solana.Unity.Examples/NameServiceClientExample.cs
+++ b/src/Solana.Unity.Examples/NameServiceClientExample.cs
@@ -1,6 +1,7 @@
 ﻿using Solana.Unity.Programs.Clients;
 using Solana.Unity.Rpc;
 using System;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {

--- a/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
+++ b/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
@@ -3,6 +3,7 @@ using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Builders;
 using Solana.Unity.Wallet;
 using System;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -48,17 +49,17 @@ namespace Solana.Unity.Examples
             return nameAccountKey;
         }
 
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(MnemonicWords);
 
-            var blockHash = rpcClient.GetRecentBlockHash();
+            var blockHash = await rpcClient.GetRecentBlockHashAsync();
             var minBalanceForExemptionNameAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(NameServiceProgram.NameAccountSize + 96).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(NameServiceProgram.NameAccountSize + 96)).Result;
 
             Console.WriteLine($"MinBalanceForRentExemption NameAccount >> {minBalanceForExemptionNameAcc}");
             var minBalanceForExemptionNameReverseRegistry =
-                rpcClient.GetMinimumBalanceForRentExemption(96 + 18).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(96 + 18)).Result;
             Console.WriteLine($"MinBalanceForRentExemption ReverseRegistry >> {minBalanceForExemptionNameReverseRegistry}");
 
             var payerAccount = wallet.GetAccount(10);
@@ -94,11 +95,11 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 
-            var txSim = rpcClient.SimulateTransaction(tx);
+            var txSim = await rpcClient.SimulateTransactionAsync(tx);
             var logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            var txReq = rpcClient.SendTransaction(tx);
+            var txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }

--- a/src/Solana.Unity.Examples/SolanaKeygenKeyGeneration.cs
+++ b/src/Solana.Unity.Examples/SolanaKeygenKeyGeneration.cs
@@ -1,6 +1,7 @@
 using Solana.Unity.Wallet;
 using Solana.Unity.Wallet.Bip39;
 using System;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {

--- a/src/Solana.Unity.Examples/SolletKeyGeneration.cs
+++ b/src/Solana.Unity.Examples/SolletKeyGeneration.cs
@@ -1,6 +1,7 @@
 using Solana.Unity.Wallet.Bip39;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {

--- a/src/Solana.Unity.Examples/SolletKeygenKeystore.cs
+++ b/src/Solana.Unity.Examples/SolletKeygenKeystore.cs
@@ -4,6 +4,7 @@ using Solana.Unity.Wallet.Bip39;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {

--- a/src/Solana.Unity.Examples/StakeExample.cs
+++ b/src/Solana.Unity.Examples/StakeExample.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using static Solana.Unity.Programs.Models.Stake.State;
 using Solana.Unity.Wallet.Bip39;
 using Solana.Unity.Wallet.Utilities;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -19,12 +20,12 @@ namespace Solana.Unity.Examples
 
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minBalance = rpcClient.GetMinimumBalanceForRentExemption(StakeProgram.StakeAccountDataSize).Result;
+            await rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "yrdy1", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
             Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
@@ -42,11 +43,11 @@ namespace Solana.Unity.Examples
                      StakeProgram.ProgramIdKey))
                 .Build(new List<Account> { fromAccount });
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx, skipPreflight: true);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx, skipPreflight: true);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }
@@ -56,18 +57,18 @@ namespace Solana.Unity.Examples
 
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             var seed = wallet.DeriveMnemonicSeed();
             var b58 = new Base58Encoder();
             string f = b58.EncodeData(seed);
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minbalanceforexception = rpcClient.GetMinimumBalanceForRentExemption(StakeProgram.StakeAccountDataSize).Result;
+            rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
-            rpcClient.RequestAirdrop(toAccount.PublicKey, 100_000_000);
+            rpcClient.RequestAirdropAsync(toAccount.PublicKey, 100_000_000);
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog5", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
 
             Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
@@ -86,11 +87,11 @@ namespace Solana.Unity.Examples
                 .Build(new List<Account> { fromAccount });
 
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx, skipPreflight: true);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx, skipPreflight: true);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }
@@ -100,11 +101,11 @@ namespace Solana.Unity.Examples
 
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
@@ -123,11 +124,11 @@ namespace Solana.Unity.Examples
                     fromAccount))
                 .Build(new List<Account> { fromAccount });
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx, skipPreflight: true);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx, skipPreflight: true);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }
@@ -137,12 +138,12 @@ namespace Solana.Unity.Examples
 
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minbalanceforexception = rpcClient.GetMinimumBalanceForRentExemption(StakeProgram.StakeAccountDataSize).Result;
+            rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog5", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
             Authorized authorized = new Authorized()
@@ -177,11 +178,11 @@ namespace Solana.Unity.Examples
                 .Build(new List<Account> { fromAccount });
 
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }
@@ -192,12 +193,12 @@ namespace Solana.Unity.Examples
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
 
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minbalanceforexception = rpcClient.GetMinimumBalanceForRentExemption(StakeProgram.StakeAccountDataSize).Result;
+            rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account stakeAccount = wallet.GetAccount(22);
 
@@ -230,11 +231,11 @@ namespace Solana.Unity.Examples
                     lockup))
                 .Build(new List<Account> { fromAccount, stakeAccount });
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }
@@ -245,12 +246,12 @@ namespace Solana.Unity.Examples
         private const string MnemonicWords =
            "clerk shoe noise umbrella apple gold alien swap desert rubber truck okay twenty fiscal near talent drastic present leg put balcony leader access glimpse";
 
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
-            rpcClient.RequestAirdrop(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minBalance = rpcClient.GetMinimumBalanceForRentExemption(StakeProgram.StakeAccountDataSize).Result;
+            rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
 
             Account a6 = wallet.GetAccount(6);
             Account a5 = wallet.GetAccount(5);
@@ -277,11 +278,11 @@ namespace Solana.Unity.Examples
                     ))
                 .CompileMessage();
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
 
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"First Tx Result: {firstSig.Result}");
         }
     }

--- a/src/Solana.Unity.Examples/TokenSwapExample.cs
+++ b/src/Solana.Unity.Examples/TokenSwapExample.cs
@@ -20,11 +20,11 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             //how to load current state
             IRpcClient mainnetRpc = ClientFactory.GetClient(Cluster.MainNet);
-            var resp = mainnetRpc.GetAccountInfo("GAM8dQkm4LwYJgPZbML61mKPUCQX7uAquxu67p9oifSK");
+            var resp = await mainnetRpc.GetAccountInfoAsync("GAM8dQkm4LwYJgPZbML61mKPUCQX7uAquxu67p9oifSK");
             var obj = TokenSwapAccount.Deserialize(Convert.FromBase64String(resp.Result.Value.Data[0]));
             Console.WriteLine($"Pool Mint: {obj.PoolMint}");
 
@@ -36,35 +36,35 @@ namespace Solana.Unity.Examples
             var tokenBUserAccount = new Account();
 
             //setup some mints and tokens owned by wallet
-            RequestResult<ResponseValue<BlockHash>> blockHash = RpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
             var tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     tokenAMint,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result,
                     TokenProgram.MintAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     tokenBMint,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result,
                     TokenProgram.MintAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     tokenAUserAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     tokenBUserAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -101,7 +101,7 @@ namespace Solana.Unity.Examples
                     wallet.Account
                 ))
                 .Build(new Account[] { wallet.Account, tokenAMint, tokenBMint, tokenAUserAccount, tokenBUserAccount });
-            var txSig = Examples.SubmitTxSendAndLog(tx);
+            var txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             var swap = new Account();
@@ -112,14 +112,14 @@ namespace Solana.Unity.Examples
             var swapTokenBAccount = new Account();
 
             //init the swap authority's token accounts
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     swapTokenAAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -137,7 +137,7 @@ namespace Solana.Unity.Examples
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     swapTokenBAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -153,7 +153,7 @@ namespace Solana.Unity.Examples
                     wallet.Account
                 ))
                 .Build(new Account[] { wallet.Account, swapTokenAAccount, swapTokenBAccount });
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             var poolMint = new Account();
@@ -161,14 +161,14 @@ namespace Solana.Unity.Examples
             var poolFeeAccount = new Account();
 
             //create the pool mint and the user and fee pool token accounts
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     poolMint,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result,
                     TokenProgram.MintAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -180,7 +180,7 @@ namespace Solana.Unity.Examples
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     poolUserAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -192,7 +192,7 @@ namespace Solana.Unity.Examples
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     poolFeeAccount,
-                    RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result,
                     TokenProgram.TokenAccountDataSize,
                     TokenProgram.ProgramIdKey
                 ))
@@ -202,18 +202,18 @@ namespace Solana.Unity.Examples
                     program.OwnerKey
                 ))
                 .Build(new Account[] { wallet.Account, poolMint, poolUserAccount, poolFeeAccount });
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //create the swap
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
                     swap,
-                    RpcClient.GetMinimumBalanceForRentExemption((long)TokenSwapProgram.TokenSwapAccountDataSize).Result,
+                    (await RpcClient.GetMinimumBalanceForRentExemptionAsync((long)TokenSwapProgram.TokenSwapAccountDataSize)).Result,
                     TokenSwapProgram.TokenSwapAccountDataSize,
                     program.ProgramIdKey
                 ))
@@ -243,11 +243,11 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"Pool Mint Account: {poolMint}");
             Console.WriteLine($"Pool User Account: {poolUserAccount}");
             Console.WriteLine($"Pool Fee Account: {poolFeeAccount}");
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //now a user can swap in the pool
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
@@ -264,11 +264,11 @@ namespace Solana.Unity.Examples
                     1_000_000_000,
                     500_000))
                 .Build(wallet.Account);
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //user can add liq
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
@@ -285,11 +285,11 @@ namespace Solana.Unity.Examples
                     100_000_000_000,
                     100_000_000_000))
                 .Build(wallet.Account);
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //user can remove liq
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
@@ -307,11 +307,11 @@ namespace Solana.Unity.Examples
                     1_000,
                     1_000))
                 .Build(wallet.Account);
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //user can deposit single
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
@@ -326,11 +326,11 @@ namespace Solana.Unity.Examples
                     1_000_000_000,
                     1_000))
                 .Build(wallet.Account);
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
             //user can withdraw single
-            blockHash = RpcClient.GetRecentBlockHash();
+            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
                 .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
@@ -346,7 +346,7 @@ namespace Solana.Unity.Examples
                     1_000_000,
                     100_000))
                 .Build(wallet.Account);
-            txSig = Examples.SubmitTxSendAndLog(tx);
+            txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
         }
     }

--- a/src/Solana.Unity.Examples/TokenWalletExample.cs
+++ b/src/Solana.Unity.Examples/TokenWalletExample.cs
@@ -3,6 +3,7 @@ using Solana.Unity.Extensions.TokenMint;
 using Solana.Unity.Rpc;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -15,7 +16,7 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
 
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
@@ -26,7 +27,7 @@ namespace Solana.Unity.Examples
             tokens.Add(new TokenDef("AHRNasvVB8UDkU9knqPcn4aVfRbnbVC9HJgSTBwbx8re", "Solnet Test Token", "STT", 2));
 
             // load snapshot of wallet and sub-accounts
-            TokenWallet tokenWallet = TokenWallet.Load(RpcClient, tokens, ownerAccount);
+            TokenWallet tokenWallet = await TokenWallet.LoadAsync(RpcClient, tokens, ownerAccount);
             var balances = tokenWallet.Balances();
             var maxsym = balances.Max(x => x.Symbol.Length);
             var maxname = balances.Max(x => x.TokenName.Length);

--- a/src/Solana.Unity.Examples/TransactionBuilderExample.cs
+++ b/src/Solana.Unity.Examples/TransactionBuilderExample.cs
@@ -8,6 +8,7 @@ using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -19,14 +20,14 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
 
             byte[] tx = new TransactionBuilder()
@@ -37,10 +38,10 @@ namespace Solana.Unity.Examples
                 .Build(fromAccount);
 
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"First Tx Signature: {firstSig.Result}");
         }
     }
@@ -53,17 +54,17 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account mintAccount = wallet.GetAccount(2222);
@@ -106,11 +107,11 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -123,17 +124,17 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account mintAccount = wallet.GetAccount(21);
@@ -155,11 +156,11 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -172,12 +173,12 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
-            ulong minBalanceForExemptionAcc = rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            ulong minBalanceForExemptionAcc = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             Account mintAccount = wallet.GetAccount(31);
@@ -211,11 +212,11 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -228,13 +229,13 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
             Account mintAccount = wallet.GetAccount(21);
@@ -273,11 +274,11 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
 
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -289,13 +290,13 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(NonceAccount.AccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(NonceAccount.AccountDataSize)).Result;
 
             Account ownerAccount = wallet.GetAccount(10);
             Console.WriteLine($"OwnerAccount: {ownerAccount}");
@@ -321,11 +322,11 @@ namespace Solana.Unity.Examples
 
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -337,7 +338,7 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
@@ -349,7 +350,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"ToAccount: {toAccount}");
 
             // Get the Nonce Account to get the Nonce to use for the transaction
-            RequestResult<ResponseValue<AccountInfo>> nonceAccountInfo = rpcClient.GetAccountInfo(nonceAccount.PublicKey);
+            RequestResult<ResponseValue<AccountInfo>> nonceAccountInfo = await rpcClient.GetAccountInfoAsync(nonceAccount.PublicKey);
             byte[] accountDataBytes = Convert.FromBase64String(nonceAccountInfo.Result.Value.Data[0]);
             NonceAccount nonceAccountData = NonceAccount.Deserialize(accountDataBytes);
             Console.WriteLine($"NonceAccount Authority: {nonceAccountData.Authorized.Key}");
@@ -377,11 +378,11 @@ namespace Solana.Unity.Examples
                 .Build(ownerAccount);
 
             Console.WriteLine($"Tx: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
-            RequestResult<string> txReq = rpcClient.SendTransaction(tx);
+            RequestResult<string> txReq = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"Tx Signature: {txReq.Result}");
         }
     }
@@ -394,20 +395,20 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
 
             ulong minBalanceForExemptionMultiSig =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MultisigAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
             ulong minBalanceForExemptionAcc =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             ulong minBalanceForExemptionMint =
-                rpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
 
             Account ownerAccount = wallet.GetAccount(10);
@@ -432,7 +433,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = Examples.LogTransactionAndSerialize(tx);
 
-            string mintToSignature = Examples.SubmitTxSendAndLog(txBytes);
+            string mintToSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(mintToSignature);
         }
     }
@@ -445,14 +446,14 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = rpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
 
             TransactionBuilder txBuilder = new TransactionBuilder()
@@ -468,10 +469,10 @@ namespace Solana.Unity.Examples
                 .Serialize();
 
             Console.WriteLine($"Tx base64: {Convert.ToBase64String(tx)}");
-            RequestResult<ResponseValue<SimulationLogs>> txSim = rpcClient.SimulateTransaction(tx);
+            RequestResult<ResponseValue<SimulationLogs>> txSim = await rpcClient.SimulateTransactionAsync(tx);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
-            RequestResult<string> firstSig = rpcClient.SendTransaction(tx);
+            RequestResult<string> firstSig = await rpcClient.SendTransactionAsync(tx);
             Console.WriteLine($"First Tx Signature: {firstSig.Result}");
         }
     }

--- a/src/Solana.Unity.Examples/TransactionDecodingExample.cs
+++ b/src/Solana.Unity.Examples/TransactionDecodingExample.cs
@@ -10,6 +10,7 @@ using Solana.Unity.Wallet.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Solana.Unity.Examples
 {
@@ -22,15 +23,15 @@ namespace Solana.Unity.Examples
             "route clerk disease box emerge airport loud waste attitude film army tray " +
             "forward deal onion eight catalog surface unit card window walnut wealth medal";
 
-        public void Run()
+        public async void Run()
         {
             var wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = RpcClient.GetRecentBlockHash();
+            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
-                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.TokenAccountDataSize).Result;
+                (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             ulong minBalanceForExemptionMint =
-                RpcClient.GetMinimumBalanceForRentExemption(TokenProgram.MintAccountDataSize).Result;
+                (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
 
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
             Console.WriteLine($"MinBalanceForRentExemption Mint Account >> {minBalanceForExemptionMint}");
@@ -82,7 +83,7 @@ namespace Solana.Unity.Examples
 
             byte[] txBytes = txx.Serialize();
 
-            var txSim = RpcClient.SimulateTransaction(txBytes);
+            var txSim = await RpcClient.SimulateTransactionAsync(txBytes);
             string logs = Examples.PrettyPrintTransactionSimulationLogs(txSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txSim.Result.Value.Error}\n\tLogs: \n" + logs);
 
@@ -108,7 +109,7 @@ namespace Solana.Unity.Examples
             }
 
             var txDecBytes = tx.Serialize();
-            var txDecSim = RpcClient.SimulateTransaction(txDecBytes);
+            var txDecSim = await RpcClient.SimulateTransactionAsync(txDecBytes);
             string decLogs = Examples.PrettyPrintTransactionSimulationLogs(txDecSim.Result.Value.Logs);
             Console.WriteLine($"Transaction Simulation:\n\tError: {txDecSim.Result.Value.Error}\n\tLogs: \n" + decLogs);
         }

--- a/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
@@ -145,10 +145,8 @@ namespace Solana.Unity.Rpc.Core.Http
             RequestResult<T> result = new(response);
             try
             {
-                if (result.HttpStatusCode != HttpStatusCode.OK)
-                    return result;
-                
-                result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (response.Content != null)
+                    result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (_logger != null)
                 {
@@ -274,9 +272,8 @@ namespace Solana.Unity.Rpc.Core.Http
             RequestResult<JsonRpcBatchResponse> result = new(response);
             try
             {
-                if (result.HttpStatusCode != HttpStatusCode.OK)
-                    return result;
-                result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (response.Content != null)
+                    result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (_logger != null)
                 {

--- a/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
+++ b/src/Solana.Unity.Rpc/Core/Http/JsonRpcClient.cs
@@ -145,6 +145,9 @@ namespace Solana.Unity.Rpc.Core.Http
             RequestResult<T> result = new(response);
             try
             {
+                if (result.HttpStatusCode != HttpStatusCode.OK)
+                    return result;
+                
                 result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (_logger != null)
@@ -268,9 +271,11 @@ namespace Solana.Unity.Rpc.Core.Http
         private async Task<RequestResult<JsonRpcBatchResponse>> HandleBatchResult(JsonRpcBatchRequest reqs, HttpResponseMessage response)
         {
             var id_for_log = reqs.Min(x => x.Id);
-            RequestResult<JsonRpcBatchResponse> result = new RequestResult<JsonRpcBatchResponse>(response);
+            RequestResult<JsonRpcBatchResponse> result = new(response);
             try
             {
+                if (result.HttpStatusCode != HttpStatusCode.OK)
+                    return result;
                 result.RawRpcResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (_logger != null)

--- a/src/Solana.Unity.Rpc/IRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IRpcClient.cs
@@ -29,18 +29,8 @@ namespace Solana.Unity.Rpc
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<ResponseValue<TokenMintInfo>>> GetTokenMintInfoAsync(string pubKey,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the token mint info. This method only works if the target account is a SPL token mint.
-        /// <remarks>
-        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </remarks>
-        /// </summary>
-        /// <param name="pubKey">The token mint public key.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<TokenMintInfo>> GetTokenMintInfo(string pubKey, Commitment commitment = Commitment.Finalized);
-
+        
+        
         /// <summary>
         /// Gets the token account info.
         /// <remarks>
@@ -52,18 +42,7 @@ namespace Solana.Unity.Rpc
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<ResponseValue<TokenAccountInfo>>> GetTokenAccountInfoAsync(string pubKey,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the token account info.
-        /// <remarks>
-        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </remarks>
-        /// </summary>
-        /// <param name="pubKey">The token account public key.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<TokenAccountInfo>> GetTokenAccountInfo(string pubKey, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the account info.
         /// <remarks>
@@ -76,20 +55,7 @@ namespace Solana.Unity.Rpc
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<ResponseValue<AccountInfo>>> GetAccountInfoAsync(string pubKey,
             Commitment commitment = Commitment.Finalized, BinaryEncoding encoding = BinaryEncoding.Base64);
-
-        /// <summary>
-        /// Gets the account info.
-        /// <remarks>
-        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </remarks>
-        /// </summary>
-        /// <param name="pubKey">The account public key.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="encoding">The encoding of the account data.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<AccountInfo>> GetAccountInfo(string pubKey, Commitment commitment = Commitment.Finalized,
-            BinaryEncoding encoding = BinaryEncoding.Base64);
-
+        
         /// <summary>
         /// Gets the balance <b>asynchronously</b> for a certain public key.
         /// <remarks>
@@ -100,18 +66,7 @@ namespace Solana.Unity.Rpc
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>A task which may return a request result holding the context and address balance.</returns>
         Task<RequestResult<ResponseValue<ulong>>> GetBalanceAsync(string pubKey, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the balance <b>synchronously</b> for a certain public key.
-        /// <remarks>
-        /// The <c>commitment</c> parameter is optional, the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </remarks>
-        /// </summary>
-        /// <param name="pubKey">The public key.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<ulong>> GetBalance(string pubKey, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns identity and transaction information about a block in the ledger.
         /// <remarks>
@@ -158,82 +113,21 @@ namespace Solana.Unity.Rpc
         [Obsolete("Please use GetBlockAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<BlockInfo>> GetConfirmedBlockAsync(ulong slot, Commitment commitment = Commitment.Finalized,
             TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
-
-        /// <summary>
-        /// Returns identity and transaction information about a block in the ledger.
-        /// <remarks>
-        /// <para>
-        /// The <c>commitment</c> parameter is optional, <see cref="Commitment.Processed"/> is not supported,
-        /// the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </para>
-        /// <para>
-        /// The <c>transactionDetails</c> parameter is optional, the default value <see cref="TransactionDetailsFilterType.Full"/> is not sent.
-        /// </para>
-        /// <para>
-        /// The <c>blockRewards</c> parameter is optional, the default value, <c>false</c>, is not sent.
-        /// </para>
-        /// </remarks>
-        /// </summary>
-        /// <param name="slot">The slot.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
-        /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<BlockInfo> GetBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
-
-        /// <summary>
-        /// Returns identity and transaction information about a confirmed block in the ledger.
-        /// <remarks>
-        /// <para>
-        /// The <c>commitment</c> parameter is optional, <see cref="Commitment.Processed"/> is not supported,
-        /// the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </para>
-        /// <para>
-        /// The <c>transactionDetails</c> parameter is optional, the default value <see cref="TransactionDetailsFilterType.Full"/> is not sent.
-        /// </para>
-        /// <para>
-        /// The <c>blockRewards</c> parameter is optional, the default value, <c>false</c>, is not sent.
-        /// </para>
-        /// </remarks>
-        /// </summary>
-        /// <param name="slot">The slot.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="transactionDetails">The level of transaction detail to return, see <see cref="TransactionDetailsFilterType"/>.</param>
-        /// <param name="blockRewards">Whether to populate the <c>rewards</c> array, the default includes rewards.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        [Obsolete("Please use GetBlock whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<BlockInfo> GetConfirmedBlock(ulong slot, Commitment commitment = Commitment.Finalized,
-            TransactionDetailsFilterType transactionDetails = TransactionDetailsFilterType.Full, bool blockRewards = false);
-
+        
         /// <summary>
         /// Gets the block commitment of a certain block, identified by slot.
         /// </summary>
         /// <param name="slot">The slot.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<BlockCommitment>> GetBlockCommitmentAsync(ulong slot);
-
-        /// <summary>
-        /// Gets the block commitment of a certain block, identified by slot.
-        /// </summary>
-        /// <param name="slot">The slot.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<BlockCommitment> GetBlockCommitment(ulong slot);
-
+        
         /// <summary>
         /// Gets the current block height of the node.
         /// </summary>
         /// <param name="commitment">The commitment state to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetBlockHeightAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the current block height of the node.
-        /// </summary>
-        /// <param name="commitment">The commitment state to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetBlockHeight(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns recent block production information from the current or previous epoch.
         /// <remarks>
@@ -247,21 +141,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<BlockProductionInfo>>> GetBlockProductionAsync(string identity = null,
             ulong? firstSlot = null, ulong? lastSlot = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns recent block production information from the current or previous epoch.
-        /// </summary>
-        /// <remarks>
-        /// All the arguments are optional, but the lastSlot must be paired with a firstSlot argument.
-        /// </remarks>
-        /// <param name="identity">Filter production details only for this given validator.</param>
-        /// <param name="firstSlot">The first slot to return production information (inclusive).</param>
-        /// <param name="lastSlot">The last slot to return production information (inclusive and optional).</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<BlockProductionInfo>> GetBlockProduction(string identity = null,
-            ulong? firstSlot = null, ulong? lastSlot = null, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns a list of blocks between two slots.
         /// </summary>
@@ -287,33 +167,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         [Obsolete("Please use GetBlocksAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<List<ulong>>> GetConfirmedBlocksAsync(ulong startSlot, ulong endSlot = 0, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns a list of blocks between two slots.
-        /// </summary>
-        /// <param name="startSlot">The start slot (inclusive).</param>
-        /// <param name="endSlot">The start slot (inclusive and optional).</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<ulong>> GetBlocks(ulong startSlot, ulong endSlot = 0,
-            Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns a list of confirmed blocks between two slots.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The <c>commitment</c> parameter is optional, <see cref="Commitment.Processed"/> is not supported,
-        /// the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </para>
-        /// </remarks>
-        /// <param name="startSlot">The start slot (inclusive).</param>
-        /// <param name="endSlot">The start slot (inclusive and optional).</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        [Obsolete("Please use GetBlocks whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<List<ulong>> GetConfirmedBlocks(ulong startSlot, ulong endSlot = 0, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns a list of confirmed blocks starting at the given slot.
         /// </summary>
@@ -334,27 +188,7 @@ namespace Solana.Unity.Rpc
         [Obsolete("Please use GetBlocksWithLimitAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<List<ulong>>> GetConfirmedBlocksWithLimitAsync(ulong startSlot,
             ulong limit, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns a list of confirmed blocks starting at the given slot.
-        /// </summary>
-        /// <param name="startSlot">The start slot (inclusive).</param>
-        /// <param name="limit">The max number of blocks to return.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<ulong>> GetBlocksWithLimit(ulong startSlot, ulong limit,
-            Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns a list of confirmed blocks starting at the given slot.
-        /// </summary>
-        /// <param name="startSlot">The start slot (inclusive).</param>
-        /// <param name="limit">The max number of blocks to return.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        [Obsolete("Please use GetBlocksWithLimit whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<List<ulong>> GetConfirmedBlocksWithLimit(ulong startSlot,
-            ulong limit, Commitment commitment = Commitment.Finalized);
+        
 
         /// <summary>
         /// Gets the estimated production time for a certain block, identified by slot.
@@ -362,52 +196,26 @@ namespace Solana.Unity.Rpc
         /// <param name="slot">The slot.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetBlockTimeAsync(ulong slot);
-
-        /// <summary>
-        /// Gets the estimated production time for a certain block, identified by slot.
-        /// </summary>
-        /// <param name="slot">The slot.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetBlockTime(ulong slot);
-
+        
         /// <summary>
         /// Gets the cluster nodes.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<List<ClusterNode>>> GetClusterNodesAsync();
-
-        /// <summary>
-        /// Gets the cluster nodes.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<ClusterNode>> GetClusterNodes();
-
+        
         /// <summary>
         /// Gets information about the current epoch.
         /// </summary>
         /// <param name="commitment">The commitment state to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<EpochInfo>> GetEpochInfoAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets information about the current epoch.
-        /// </summary>
-        /// <param name="commitment">The commitment state to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<EpochInfo> GetEpochInfo(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets epoch schedule information from this cluster's genesis config.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<EpochScheduleInfo>> GetEpochScheduleAsync();
-
-        /// <summary>
-        /// Gets epoch schedule information from this cluster's genesis config.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<EpochScheduleInfo> GetEpochSchedule();
-
+        
         /// <summary>
         /// Gets the fee calculator associated with the query blockhash, or null if the blockhash has expired.
         /// </summary>
@@ -416,28 +224,13 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<FeeCalculatorInfo>>> GetFeeCalculatorForBlockhashAsync(
             string blockhash, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the fee calculator associated with the query blockhash, or null if the blockhash has expired.
-        /// </summary>
-        /// <param name="blockhash">The blockhash to query, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<FeeCalculatorInfo>> GetFeeCalculatorForBlockhash(string blockhash,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the fee rate governor information from the root bank.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<FeeRateGovernorInfo>>> GetFeeRateGovernorAsync();
-
-        /// <summary>
-        /// Gets the fee rate governor information from the root bank.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<FeeRateGovernorInfo>> GetFeeRateGovernor();
-
+        
         /// <summary>
         /// Gets a recent block hash from the ledger, a fee schedule that can be used to compute the
         /// cost of submitting a transaction using it, and the last slot in which the blockhash will be valid.
@@ -445,91 +238,45 @@ namespace Solana.Unity.Rpc
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<FeesInfo>>> GetFeesAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets a recent block hash from the ledger, a fee schedule that can be used to compute the
-        /// cost of submitting a transaction using it, and the last slot in which the blockhash will be valid.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<FeesInfo>> GetFees(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns the slot of the lowest confirmed block that has not been purged from the ledger.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetFirstAvailableBlockAsync();
-
-        /// <summary>
-        /// Returns the slot of the lowest confirmed block that has not been purged from the ledger.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetFirstAvailableBlock();
-
+        
         /// <summary>
         /// Gets the genesis hash of the ledger.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> GetGenesisHashAsync();
-
-        /// <summary>
-        /// Gets the genesis hash of the ledger.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> GetGenesisHash();
-
+        
         /// <summary>
         /// Returns the current health of the node. 
         /// This method should return the string 'ok' if the node is healthy, or the error code along with any information provided otherwise. 
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> GetHealthAsync();
-
-        /// <summary>
-        /// Returns the current health of the node. 
-        /// This method should return the string 'ok' if the node is healthy, or the error code along with any information provided otherwise. 
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> GetHealth();
-
+        
         /// <summary>
         /// Gets the identity pubkey for the current node.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<NodeIdentity>> GetIdentityAsync();
-
-        /// <summary>
-        /// Gets the identity pubkey for the current node.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<NodeIdentity> GetIdentity();
-
+        
         /// <summary>
         /// Gets the current inflation governor.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<InflationGovernor>> GetInflationGovernorAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the current inflation governor.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<InflationGovernor> GetInflationGovernor(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the specific inflation values for the current epoch.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<InflationRate>> GetInflationRateAsync();
-
-        /// <summary>
-        /// Gets the specific inflation values for the current epoch.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<InflationRate> GetInflationRate();
-
+        
         /// <summary>
         /// Gets the inflation reward for a list of addresses for an epoch.
         /// </summary>
@@ -539,17 +286,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<List<InflationReward>>> GetInflationRewardAsync(IList<string> addresses,
             ulong epoch = 0, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the inflation reward for a list of addresses for an epoch.
-        /// </summary>
-        /// <param name="addresses">The list of addresses to query, as base-58 encoded strings.</param>
-        /// <param name="epoch">The epoch.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<InflationReward>> GetInflationReward(IList<string> addresses, ulong epoch = 0,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the 20 largest accounts, by lamport balance.
         /// </summary>
@@ -559,17 +296,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<List<LargeAccount>>>> GetLargestAccountsAsync(AccountFilterType? filter = null,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the 20 largest accounts, by lamport balance.
-        /// </summary>
-        /// <remarks>Results may be cached up to two hours.</remarks>
-        /// <param name="filter">Filter results by account type.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<LargeAccount>>> GetLargestAccounts(AccountFilterType? filter = null,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns the leader schedule for an epoch.
         /// </summary>
@@ -580,42 +307,19 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<Dictionary<string, List<ulong>>>> GetLeaderScheduleAsync(ulong slot = 0,
             string identity = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns the leader schedule for an epoch.
-        /// </summary>
-        /// <param name="slot">Fetch the leader schedule for the epoch that corresponds to the provided slot. 
-        /// If unspecified, the leader schedule for the current epoch is fetched.</param>
-        /// <param name="identity">Filter results for this validator only (base 58 encoded string and optional).</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<Dictionary<string, List<ulong>>> GetLeaderSchedule(ulong slot = 0,
-            string identity = null, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the maximum slot seen from retransmit stage.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetMaxRetransmitSlotAsync();
-
-        /// <summary>
-        /// Gets the maximum slot seen from retransmit stage.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetMaxRetransmitSlot();
-
+        
         /// <summary>
         /// Gets the maximum slot seen from after shred insert.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetMaxShredInsertSlotAsync();
-
-        /// <summary>
-        /// Gets the maximum slot seen from after shred insert.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetMaxShredInsertSlot();
-
+        
         /// <summary>
         /// Gets the minimum balance required to make account rent exempt.
         /// </summary>
@@ -624,16 +328,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetMinimumBalanceForRentExemptionAsync(long accountDataSize,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the minimum balance required to make account rent exempt.
-        /// </summary>
-        /// <param name="accountDataSize">The account data size.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetMinimumBalanceForRentExemption(long accountDataSize,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the lowest slot that the node has information about in its ledger.
         /// <remarks>
@@ -642,16 +337,7 @@ namespace Solana.Unity.Rpc
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetMinimumLedgerSlotAsync();
-
-        /// <summary>
-        /// Gets the lowest slot that the node has information about in its ledger.
-        /// <remarks>
-        /// This value may decrease over time if a node is configured to purging data.
-        /// </remarks>
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetMinimumLedgerSlot();
-
+        
         /// <summary>
         /// Gets the account info for multiple accounts.
         /// </summary>
@@ -660,16 +346,7 @@ namespace Solana.Unity.Rpc
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<ResponseValue<List<AccountInfo>>>> GetMultipleAccountsAsync(IList<string> accounts,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the account info for multiple accounts.
-        /// </summary>
-        /// <param name="accounts">The list of the accounts public keys.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<AccountInfo>>> GetMultipleAccounts(IList<string> accounts,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns all accounts owned by the provided program Pubkey.
         /// <remarks>Accounts must meet all filter criteria to be included in the results.</remarks>
@@ -681,33 +358,14 @@ namespace Solana.Unity.Rpc
         /// <returns>A task which may return a request result holding the context and account info.</returns>
         Task<RequestResult<List<AccountKeyPair>>> GetProgramAccountsAsync(string pubKey, Commitment commitment = Commitment.Finalized,
             int? dataSize = null, IList<MemCmp> memCmpList = null);
-
-        /// <summary>
-        /// Returns all accounts owned by the provided program Pubkey.
-        /// <remarks>Accounts must meet all filter criteria to be included in the results.</remarks>
-        /// </summary>
-        /// <param name="pubKey">The program public key.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <param name="dataSize">The data size of the account to compare against the program account data.</param>
-        /// <param name="memCmpList">The list of comparisons to match against the program account data.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<AccountKeyPair>> GetProgramAccounts(string pubKey, Commitment commitment = Commitment.Finalized,
-            int? dataSize = null, IList<MemCmp> memCmpList = null);
-
+        
         /// <summary>
         /// Gets a recent block hash.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<BlockHash>>> GetRecentBlockHashAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets a recent block hash.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<BlockHash>> GetRecentBlockHash(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets a list of recent performance samples.
         /// <remarks>
@@ -717,17 +375,7 @@ namespace Solana.Unity.Rpc
         /// <param name="limit">Maximum transaction signatures to return, between 1-720. Default is 720.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<List<PerformanceSample>>> GetRecentPerformanceSamplesAsync(ulong limit = 720);
-
-        /// <summary>
-        /// Gets a list of recent performance samples.
-        /// <remarks>
-        /// Unless <c>searchTransactionHistory</c> is included, this method only searches the recent status cache of signatures.
-        /// </remarks>
-        /// </summary>
-        /// <param name="limit">Maximum transaction signatures to return, between 1-720. Default is 720.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<PerformanceSample>> GetRecentPerformanceSamples(ulong limit = 720);
-
+        
         /// <summary>
         /// Gets signatures with the given commitment for transactions involving the address.
         /// <remarks>
@@ -758,37 +406,7 @@ namespace Solana.Unity.Rpc
         [Obsolete("Please use GetSignaturesForAddressAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<List<SignatureStatusInfo>>> GetConfirmedSignaturesForAddress2Async(string accountPubKey, ulong limit = 1000,
             string before = null, string until = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets signatures with the given commitment for transactions involving the address.
-        /// <remarks>
-        /// Unless <c>searchTransactionHistory</c> is included, this method only searches the recent status cache of signatures.
-        /// </remarks>
-        /// </summary>
-        /// <param name="accountPubKey">The account address as base-58 encoded string.</param>
-        /// <param name="limit">Maximum transaction signatures to return, between 1-1000. Default is 1000.</param>
-        /// <param name="before">Start searching backwards from this transaction signature.</param>
-        /// <param name="until">Search until this transaction signature, if found before limit is reached.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<SignatureStatusInfo>> GetSignaturesForAddress(string accountPubKey, ulong limit = 1000,
-            string before = null, string until = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets confirmed signatures for transactions involving the address.
-        /// <remarks>
-        /// Unless <c>searchTransactionHistory</c> is included, this method only searches the recent status cache of signatures.
-        /// </remarks>
-        /// </summary>
-        /// <param name="accountPubKey">The account address as base-58 encoded string.</param>
-        /// <param name="limit">Maximum transaction signatures to return, between 1-1000. Default is 1000.</param>
-        /// <param name="before">Start searching backwards from this transaction signature.</param>
-        /// <param name="until">Search until this transaction signature, if found before limit is reached.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        [Obsolete("Please use GetSignaturesForAddress whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<List<SignatureStatusInfo>> GetConfirmedSignaturesForAddress2(string accountPubKey, ulong limit = 1000,
-            string before = null, string until = null, Commitment commitment = Commitment.Finalized);
+        
 
         /// <summary>
         /// Gets the status of a list of signatures.
@@ -803,45 +421,19 @@ namespace Solana.Unity.Rpc
             bool searchTransactionHistory = false);
 
         /// <summary>
-        /// Gets the status of a list of signatures.
-        /// <remarks>
-        /// Unless <c>searchTransactionHistory</c> is included, this method only searches the recent status cache of signatures.
-        /// </remarks>
-        /// </summary>
-        /// <param name="transactionHashes">The list of transactions to search status info for.</param>
-        /// <param name="searchTransactionHistory">If the node should search for signatures in it's ledger cache.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<SignatureStatusInfo>>> GetSignatureStatuses(List<string> transactionHashes,
-            bool searchTransactionHistory = false);
-
-        /// <summary>
         /// Gets the current slot the node is processing
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetSlotAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the current slot the node is processing
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetSlot(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the current slot leader.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> GetSlotLeaderAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the current slot leader.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> GetSlotLeader(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the slot leaders for a given slot range.
         /// </summary>
@@ -851,27 +443,12 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<List<string>>> GetSlotLeadersAsync(ulong start, ulong limit,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the slot leaders for a given slot range.
-        /// </summary>
-        /// <param name="start">The start slot.</param>
-        /// <param name="limit">The result limit.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<List<string>> GetSlotLeaders(ulong start, ulong limit, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the highest slot that the node has a snapshot for.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetSnapshotSlotAsync();
-
-        /// <summary>
-        /// Gets the highest slot that the node has a snapshot for.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetSnapshotSlot();
 
         /// <summary>
         /// Gets the epoch activation information for a stake account.
@@ -884,28 +461,11 @@ namespace Solana.Unity.Rpc
             Commitment commitment = Commitment.Finalized);
 
         /// <summary>
-        /// Gets the epoch activation information for a stake account.
-        /// </summary>
-        /// <param name="publicKey">Public key of account to query, as base-58 encoded string</param>
-        /// <param name="epoch">Epoch for which to calculate activation details.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<StakeActivationInfo> GetStakeActivation(string publicKey, ulong epoch = 0,
-            Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
         /// Gets information about the current supply.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<Supply>>> GetSupplyAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets information about the current supply.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<Supply>> GetSupply(Commitment commitment = Commitment.Finalized);
         
         /// <summary>
         /// Gets the token balance for an account, given the token mint.
@@ -918,20 +478,6 @@ namespace Solana.Unity.Rpc
             string ownerPubKey,
             string tokenMintPubKey,
             Commitment commitment = Commitment.Finalized);
-        
-        
-        /// <summary>
-        /// Gets the token balance for an account, given the token mint.
-        /// </summary>
-        /// <param name="ownerPubKey">Public key of account owner query, as base-58 encoded string.</param>
-        /// <param name="tokenMintPubKey">Public key of the specific token Mint to limit accounts to, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
-        RequestResult<ResponseValue<TokenBalance>> GetTokenBalanceByOwner(
-            string ownerPubKey,
-            string tokenMintPubKey,
-            Commitment commitment = Commitment.Finalized);
-
 
         /// <summary>
         /// Gets the token balance of an SPL Token account.
@@ -941,16 +487,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<TokenBalance>>> GetTokenAccountBalanceAsync(string splTokenAccountPublicKey,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the token balance of an SPL Token account.
-        /// </summary>
-        /// <param name="splTokenAccountPublicKey">Public key of Token account to query, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<TokenBalance>> GetTokenAccountBalance(string splTokenAccountPublicKey,
-            Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets all SPL Token accounts by approved delegate.
         /// </summary>
@@ -961,18 +498,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<List<TokenAccount>>>> GetTokenAccountsByDelegateAsync(
             string ownerPubKey, string tokenMintPubKey = null, string tokenProgramId = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets all SPL Token accounts by approved delegate.
-        /// </summary>
-        /// <param name="ownerPubKey">Public key of account owner query, as base-58 encoded string.</param>
-        /// <param name="tokenMintPubKey">Public key of the specific token Mint to limit accounts to, as base-58 encoded string.</param>
-        /// <param name="tokenProgramId">Public key of the Token program ID that owns the accounts, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<TokenAccount>>> GetTokenAccountsByDelegate(
-            string ownerPubKey, string tokenMintPubKey = null, string tokenProgramId = null, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets all SPL Token accounts by token owner.
         /// </summary>
@@ -983,18 +509,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<List<TokenAccount>>>> GetTokenAccountsByOwnerAsync(
             string ownerPubKey, string tokenMintPubKey = null, string tokenProgramId = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets all SPL Token accounts by token owner.
-        /// </summary>
-        /// <param name="ownerPubKey">Public key of account owner query, as base-58 encoded string.</param>
-        /// <param name="tokenMintPubKey">Public key of the specific token Mint to limit accounts to, as base-58 encoded string.</param>
-        /// <param name="tokenProgramId">Public key of the Token program ID that owns the accounts, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<TokenAccount>>> GetTokenAccountsByOwner(
-            string ownerPubKey, string tokenMintPubKey = null, string tokenProgramId = null, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the 20 largest token accounts of a particular SPL Token.
         /// </summary>
@@ -1003,15 +518,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<List<LargeTokenAccount>>>> GetTokenLargestAccountsAsync(string tokenMintPubKey,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the 20 largest token accounts of a particular SPL Token.
-        /// </summary>
-        /// <param name="tokenMintPubKey">Public key of Token Mint to query, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<List<LargeTokenAccount>>> GetTokenLargestAccounts(string tokenMintPubKey,
-            Commitment commitment = Commitment.Finalized);
+        
 
         /// <summary>
         /// Get the token supply of an SPL Token type.
@@ -1021,15 +528,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<TokenBalance>>> GetTokenSupplyAsync(string tokenMintPubKey,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Get the token supply of an SPL Token type.
-        /// </summary>
-        /// <param name="tokenMintPubKey">Public key of Token Mint to query, as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<TokenBalance>> GetTokenSupply(string tokenMintPubKey, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
         /// <remarks>
@@ -1059,61 +558,19 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         [Obsolete("Please use GetTransactionAsync whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
         Task<RequestResult<TransactionMetaSlotInfo>> GetConfirmedTransactionAsync(string signature, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns transaction details for a confirmed transaction.
-        /// <remarks>
-        /// <para>
-        /// The <c>commitment</c> parameter is optional, <see cref="Commitment.Processed"/> is not supported,
-        /// the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </para>
-        /// </remarks>
-        /// </summary>
-        /// <param name="signature">Transaction signature as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<TransactionMetaSlotInfo> GetTransaction(string signature, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Returns transaction details for a confirmed transaction.
-        /// <remarks>
-        /// <para>
-        /// The <c>commitment</c> parameter is optional, <see cref="Commitment.Processed"/> is not supported,
-        /// the default value <see cref="Commitment.Finalized"/> is not sent.
-        /// </para>
-        /// </remarks>
-        /// </summary>
-        /// <param name="signature">Transaction signature as base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        [Obsolete("Please use GetTransaction whenever possible instead. This method is expected to be removed in solana-core v1.8.")]
-        RequestResult<TransactionMetaSlotInfo> GetConfirmedTransaction(string signature, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the total transaction count of the ledger.
         /// </summary>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ulong>> GetTransactionCountAsync(Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the total transaction count of the ledger.
-        /// </summary>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ulong> GetTransactionCount(Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Gets the current node's software version info.
         /// </summary>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<NodeVersion>> GetVersionAsync();
-
-        /// <summary>
-        /// Gets the current node's software version info.
-        /// </summary>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<NodeVersion> GetVersion();
 
         /// <summary>
         /// Gets the account info and associated stake for all voting accounts in the current bank.
@@ -1122,15 +579,7 @@ namespace Solana.Unity.Rpc
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<VoteAccounts>> GetVoteAccountsAsync(string votePubKey = null, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Gets the account info and associated stake for all voting accounts in the current bank.
-        /// </summary>
-        /// <param name="votePubKey">Filter by validator vote address, base-58 encoded string.</param>
-        /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<VoteAccounts> GetVoteAccounts(string votePubKey = null, Commitment commitment = Commitment.Finalized);
-
+        
         /// <summary>
         /// Requests an airdrop to the passed <c>pubKey</c> of the passed <c>lamports</c> amount.
         /// <remarks>
@@ -1143,19 +592,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> RequestAirdropAsync(string pubKey, ulong lamports,
             Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Requests an airdrop to the passed <c>pubKey</c> of the passed <c>lamports</c> amount.
-        /// <remarks>
-        /// The <c>commitment</c> parameter is optional, the default <see cref="Commitment.Finalized"/> is used.
-        /// </remarks>
-        /// </summary>
-        /// <param name="pubKey">The public key of to receive the airdrop.</param>
-        /// <param name="lamports">The amount of lamports to request.</param>
-        /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> RequestAirdrop(string pubKey, ulong lamports,
-            Commitment commitment = Commitment.Finalized);
+        
 
         /// <summary>
         /// Sends a transaction.
@@ -1166,16 +603,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> SendTransactionAsync(string transaction, bool skipPreflight = false,
             Commitment preFlightCommitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Sends a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
-        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
-        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> SendTransaction(string transaction, bool skipPreflight = false,
-            Commitment preFlightCommitment = Commitment.Finalized);
+        
 
         /// <summary>
         /// Sends a transaction.
@@ -1186,16 +614,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<string>> SendTransactionAsync(byte[] transaction, bool skipPreflight = false,
              Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Sends a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction as byte array.</param>
-        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
-        /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> SendTransaction(byte[] transaction, bool skipPreflight = false,
-            Commitment commitment = Commitment.Finalized);
+        
         
         /// <summary>
         /// Sends and confirm transaction.
@@ -1220,28 +639,6 @@ namespace Solana.Unity.Rpc
             Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
         
         /// <summary>
-        /// Sends and confirm a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction as base-64 encoded string.</param>
-        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
-        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
-        /// <param name="commitment">The block commitment used for confirmation.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> SendAndConfirmTransaction(string transaction, bool skipPreflight = false,
-            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
-        /// Sends and confirm a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction as byte array.</param>
-        /// <param name="skipPreflight">If true skip the preflight transaction checks (default false).</param>
-        /// <param name="preFlightCommitment">The block commitment used for preflight.</param>
-        /// <param name="commitment">The block commitment used for confirmation.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<string> SendAndConfirmTransaction(byte[] transaction, bool skipPreflight = false,
-            Commitment preFlightCommitment = Commitment.Finalized, Commitment commitment = Commitment.Finalized);
-
-        /// <summary>
         /// Simulate sending a transaction.
         /// </summary>
         /// <param name="transaction">The signed transaction as a base-64 encoded string.</param>
@@ -1254,21 +651,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<SimulationLogs>>> SimulateTransactionAsync(string transaction, bool sigVerify = false,
             Commitment commitment = Commitment.Finalized, bool replaceRecentBlockhash = false, IList<string> accountsToReturn = null);
-
-        /// <summary>
-        /// Simulate sending a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction base-64 encoded string.</param>
-        /// <param name="sigVerify">If the transaction signatures should be verified 
-        /// (default false, conflicts with <c>replaceRecentBlockHash</c>.</param>
-        /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
-        /// <param name="replaceRecentBlockhash">If the transaction recent blockhash should be replaced with the most recent blockhash 
-        /// (default false, conflicts with <c>sigVerify</c></param>
-        /// <param name="accountsToReturn">List of accounts to return, as base-58 encoded strings.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<SimulationLogs>> SimulateTransaction(string transaction, bool sigVerify = false,
-            Commitment commitment = Commitment.Finalized, bool replaceRecentBlockhash = false, IList<string> accountsToReturn = null);
-
+        
         /// <summary>
         /// Simulate sending a transaction.
         /// </summary>
@@ -1282,21 +665,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
         Task<RequestResult<ResponseValue<SimulationLogs>>> SimulateTransactionAsync(byte[] transaction, bool sigVerify = false,
             Commitment commitment = Commitment.Finalized, bool replaceRecentBlockhash = false, IList<string> accountsToReturn = null);
-
-        /// <summary>
-        /// Simulate sending a transaction.
-        /// </summary>
-        /// <param name="transaction">The signed transaction as a byte array.</param>
-        /// <param name="sigVerify">If the transaction signatures should be verified 
-        /// (default false, conflicts with <c>replaceRecentBlockHash</c>.</param>
-        /// <param name="commitment">The block commitment used to retrieve block hashes and verify success.</param>
-        /// <param name="replaceRecentBlockhash">If the transaction recent blockhash should be replaced with the most recent blockhash 
-        /// (default false, conflicts with <c>sigVerify</c></param>
-        /// <param name="accountsToReturn">List of accounts to return, as base-58 encoded strings.</param>
-        /// <returns>Returns an object that wraps the result along with possible errors with the request.</returns>
-        RequestResult<ResponseValue<SimulationLogs>> SimulateTransaction(byte[] transaction, bool sigVerify = false,
-            Commitment commitment = Commitment.Finalized, bool replaceRecentBlockhash = false, IList<string> accountsToReturn = null);
-
+        
         /// <summary>
         /// Confirms a transaction - using polling and constant timeout based on commitment parameter.
         /// </summary>

--- a/src/Solana.Unity.Rpc/IRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IRpcClient.cs
@@ -283,7 +283,8 @@ namespace Solana.Unity.Rpc
         /// <param name="addresses">The list of addresses to query, as base-58 encoded strings.</param>
         /// <param name="epoch">The epoch.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
-        /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
+        /// <returns>Returns a task that holds the asynchronous operation result and state.
+        /// The InflationReward will be null if there is no inflation reward</returns>
         Task<RequestResult<List<InflationReward>>> GetInflationRewardAsync(IList<string> addresses,
             ulong epoch = 0, Commitment commitment = Commitment.Finalized);
         

--- a/test/Solana.Unity.Extensions.Test/TokenWalletTest.cs
+++ b/test/Solana.Unity.Extensions.Test/TokenWalletTest.cs
@@ -28,7 +28,7 @@ namespace Solana.Unity.Extensions.Test
 
 
         [TestMethod]
-        public void TestLoadKnownMint()
+        public async void TestLoadKnownMint()
         {
             // get owner
             var ownerWallet = new Wallet.Wallet(MnemonicWords);
@@ -49,7 +49,7 @@ namespace Solana.Unity.Extensions.Test
 
             // load account
             var publicKey = "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5";
-            var wallet = TokenWallet.Load(client, tokens, publicKey);
+            var wallet = await TokenWallet.LoadAsync(client, tokens, publicKey);
 
             // check wallet 
             Assert.IsNotNull(wallet);
@@ -79,7 +79,7 @@ namespace Solana.Unity.Extensions.Test
 
 
         [TestMethod]
-        public void TestLoadUnknownMint()
+        public async void TestLoadUnknownMint()
         {
             // get owner
             var ownerWallet = new Wallet.Wallet(MnemonicWords);
@@ -93,7 +93,7 @@ namespace Solana.Unity.Extensions.Test
 
             // load account
             var tokens = new TokenMintResolver();
-            var wallet = TokenWallet.Load(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            var wallet = await TokenWallet.LoadAsync(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
 
             // check wallet 
             Assert.IsNotNull(wallet);
@@ -115,7 +115,7 @@ namespace Solana.Unity.Extensions.Test
 
 
         [TestMethod]
-        public void TestProvisionAtaInjectBuilder()
+        public async void TestProvisionAtaInjectBuilder()
         {
             // get owner
             var ownerWallet = new Wallet.Wallet(MnemonicWords);
@@ -133,7 +133,7 @@ namespace Solana.Unity.Extensions.Test
             tokens.Add(testToken);
 
             // load account
-            var wallet = TokenWallet.Load(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            var wallet = await TokenWallet.LoadAsync(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
 
             // check wallet 
             Assert.IsNotNull(wallet);
@@ -164,7 +164,7 @@ namespace Solana.Unity.Extensions.Test
 
 
         [TestMethod]
-        public void TestLoadRefresh()
+        public async void TestLoadRefresh()
         {
             // get owner
             var ownerWallet = new Wallet.Wallet(MnemonicWords);
@@ -184,19 +184,19 @@ namespace Solana.Unity.Extensions.Test
             tokens.Add(testToken);
 
             // load account
-            var wallet = TokenWallet.Load(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            var wallet = await TokenWallet.LoadAsync(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
 
             // check wallet 
             Assert.IsNotNull(wallet);
 
             // refresh
-            wallet.Refresh();
+            await wallet.RefreshAsync();
 
         }
 
 
         [TestMethod]
-        public void TestSendTokenProvisionAta()
+        public async void TestSendTokenProvisionAta()
         {
 
             // get owner
@@ -223,7 +223,7 @@ namespace Solana.Unity.Extensions.Test
             tokens.Add(testToken);
 
             // load account 
-            var wallet = TokenWallet.Load(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            var wallet = await TokenWallet.LoadAsync(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
             Assert.IsNotNull(wallet);
 
             // identify test token account with some balance
@@ -237,23 +237,22 @@ namespace Solana.Unity.Extensions.Test
             client.AddTextFile("Resources/TokenWallet/GetTokenAccountsByOwnerResponse2.json");
             client.AddTextFile("Resources/TokenWallet/GetRecentBlockhashResponse.json");
             client.AddTextFile("Resources/TokenWallet/SendTransactionResponse.json");
-            wallet.Send(testTokenAccount, 1M, targetOwner, signer.PublicKey, builder => builder.Build(signer));
-
+            await wallet.SendAsync(testTokenAccount, 1M, targetOwner, signer.PublicKey, builder => builder.Build(signer));
         }
 
 
         [TestMethod, ExpectedException(typeof(AggregateException))]
-        public void TestTokenWalletLoadAddressCheck()
+        public async void TestTokenWalletLoadAddressCheck()
         {
             // try to load a made up wallet address
             var client = new MockTokenWalletRpc();
             var tokens = new TokenMintResolver();
-            TokenWallet.Load(client, tokens, "FAKEkjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            await TokenWallet.LoadAsync(client, tokens, "FAKEkjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
         }
 
 
         [TestMethod, ExpectedException(typeof(AggregateException))]
-        public void TestTokenWalletSendAddressCheck()
+        public async void TestTokenWalletSendAddressCheck()
         {
 
             // get owner
@@ -272,15 +271,14 @@ namespace Solana.Unity.Extensions.Test
             tokens.Add(testToken);
 
             // load account and identify test token account with some balance
-            var wallet = TokenWallet.Load(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
+            var wallet = await TokenWallet.LoadAsync(client, tokens, "9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5");
             Assert.IsNotNull(wallet);
             var testTokenAccount = wallet.TokenAccounts().ForToken(testToken).WithAtLeast(5M).First();
             Assert.IsFalse(testTokenAccount.IsAssociatedTokenAccount);
 
             // trigger send to bogus target wallet
             var targetOwner = "FAILzxtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5";
-            wallet.Send(testTokenAccount, 1M, targetOwner, signer.PublicKey, builder => builder.Build(signer));
-
+            await wallet.SendAsync(testTokenAccount, 1M, targetOwner, signer.PublicKey, builder => builder.Build(signer));
         }
 
 
@@ -288,7 +286,7 @@ namespace Solana.Unity.Extensions.Test
         /// Check to make sure callee can not send source TokenWalletAccount from Wallet A using Wallet B
         /// </summary>
         [TestMethod, ExpectedException(typeof(AggregateException))]
-        public void TestSendTokenDefendAgainstAccountMismatch()
+        public async void TestSendTokenDefendAgainstAccountMismatch()
         {
 
             // define mints and get owner 
@@ -304,14 +302,14 @@ namespace Solana.Unity.Extensions.Test
             Assert.AreEqual("9we6kjtbcZ2vy3GSLLsZTEhbAqXPTRvEyoxa8wxSqKp5", account_a.PublicKey.Key);
             client.AddTextFile("Resources/TokenWallet/GetBalanceResponse.json");
             client.AddTextFile("Resources/TokenWallet/GetTokenAccountsByOwnerResponse.json");
-            var wallet_a = TokenWallet.Load(client, tokens, account_a);
+            var wallet_a = await TokenWallet.LoadAsync(client, tokens, account_a);
 
             // load wallet b
             var account_b = ownerWallet.GetAccount(2);
             Assert.AreEqual("3F2RNf2f2kWYgJ2XsqcjzVeh3rsEQnwf6cawtBiJGyKV", account_b.PublicKey.Key);
             client.AddTextFile("Resources/TokenWallet/GetBalanceResponse.json");
             client.AddTextFile("Resources/TokenWallet/GetTokenAccountsByOwnerResponse2.json");
-            var wallet_b = TokenWallet.Load(client, tokens, account_b);
+            var wallet_b = await TokenWallet.LoadAsync(client, tokens, account_b);
 
             // use other account as mock target and check derived PDA
             var destination = ownerWallet.GetAccount(99);
@@ -321,7 +319,7 @@ namespace Solana.Unity.Extensions.Test
             Assert.IsFalse(account_in_a.IsAssociatedTokenAccount);
 
             // attempt to send using wallet b - this should not succeed
-            wallet_b.Send(account_in_a, 1M, destination, account_a.PublicKey, builder => builder.Build(account_b));
+            await wallet_b.SendAsync(account_in_a, 1M, destination, account_a.PublicKey, builder => builder.Build(account_b));
 
         }
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready |  Hotfix | Yes | - |

## Problem

Many synch version of async methods are blocking the main thread on Unity.

See https://stackoverflow.com/questions/14526377/why-does-this-async-action-hang-when-i-try-and-access-the-result-property-of-my for more details on the issue.


## Solution

Since sync over async is not generally a good design pattern, removed the sync version of the methods
