### PR TITLE
:bug: Fix unity code stripping

### DIFF
--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaTokens.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaTokens.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 using Solana.Unity.Dex.Models;
+using Solana.Unity.Dex.Orca.Orca;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Core.Http;
 using System;
@@ -70,14 +71,6 @@ namespace Orca
             return tokens.First(t => 
                 string.Equals(t.Symbol, symbol, StringComparison.CurrentCultureIgnoreCase) || 
                 string.Equals(t.Symbol, $"${symbol}", StringComparison.CurrentCultureIgnoreCase));
-        }
-        
-        /// <summary>
-        /// Serialized from JSON; represents the entire JSON output. 
-        /// </summary>
-        private class TokensDocument
-        {
-            public IList<TokenData> tokens; 
         }
     }
     

--- a/src/Solana.Unity.Dex/Orca/Orca/TokensDocument.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/TokensDocument.cs
@@ -1,0 +1,12 @@
+using Solana.Unity.Dex.Models;
+using System.Collections.Generic;
+
+namespace Solana.Unity.Dex.Orca.Orca;
+
+/// <summary>
+/// Serialized from JSON; represents the entire JSON output. 
+/// </summary>
+public class TokensDocument
+{
+    public List<TokenData> tokens; 
+}

--- a/src/Solana.Unity.Dex/Resources/link.xml
+++ b/src/Solana.Unity.Dex/Resources/link.xml
@@ -1,0 +1,10 @@
+<linker>
+  
+  <!--Preserve Solana.Unity.Dex assembly-->
+
+  <assembly fullname="Solana.Unity.Dex">
+    <namespace fullname="Solana.Unity.Dex" preserve="all"/>
+    <type fullname="Solana.Unity.Dex.*" preserve="all"/>
+  </assembly>
+
+</linker>

--- a/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
+++ b/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
@@ -15,6 +15,12 @@
         <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <EmbeddedResource Include="Resources\link.xml">
+        <LogicalName>Solana.Unity.Dex.xml</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+
     <Import Project="..\..\SharedBuildProperties.props" />
     
     <PropertyGroup>

--- a/src/Solana.Unity.Examples/TokenWalletExample.cs
+++ b/src/Solana.Unity.Examples/TokenWalletExample.cs
@@ -1,5 +1,5 @@
 ﻿using Solana.Unity.Extensions;
-using Solana.Unity.Extensions.TokenMint;
+using Solana.Unity.Extensions.Models.TokenMint;
 using Solana.Unity.Rpc;
 using System;
 using System.Linq;

--- a/src/Solana.Unity.Extensions/ITokenMintResolver.cs
+++ b/src/Solana.Unity.Extensions/ITokenMintResolver.cs
@@ -1,5 +1,5 @@
-﻿using Solana.Unity.Rpc.Core.Http;
-using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
+using Solana.Unity.Rpc.Core.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Solana.Unity.Extensions/Models/TokenMint/TokenDef.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenMint/TokenDef.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Solana.Unity.Extensions.TokenMint
+namespace Solana.Unity.Extensions.Models.TokenMint
 {
     /// <summary>
     /// Token Definition object used by the TokenMintResolver
@@ -142,17 +142,33 @@ namespace Solana.Unity.Extensions.TokenMint
     }
 
     /// <summary>
-    /// Internal class used to deserialize tokenlist.json
+    /// Class used to deserialize tokenlist.json
     /// </summary>
-    internal class TokenListDoc
+    public class TokenListDoc
     {
-        public IList<TokenListItem> tokens { get; set; }
+        public List<TokenListItem> tokens { get; set; }
+
+        /// <summary>
+        /// Empty constructor
+        /// </summary>
+        public TokenListDoc()
+        {
+        }
+
+        /// <summary>
+        /// Constructor with tokens
+        /// </summary>
+        /// <param name="tokens"></param>
+        public TokenListDoc(List<TokenListItem> tokens)
+        {
+            this.tokens = tokens;
+        }
     }
 
     /// <summary>
     /// Internal class used to deserialize tokenlist.json
     /// </summary>
-    internal class TokenListItem
+    public class TokenListItem
     {
         public string Address { get; set; }
         public string Symbol { get; set; }
@@ -160,6 +176,13 @@ namespace Solana.Unity.Extensions.TokenMint
         public int Decimals { get; set; }
         public string LogoUri { get; set; }
         public Dictionary<string, object> Extensions { get; set; }
+        
+        /// <summary>
+        /// Empty constructor
+        /// </summary>
+        public TokenListItem()
+        {
+        }
     }
 
 }

--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenQuantity.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenQuantity.cs
@@ -1,4 +1,4 @@
-﻿using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletAccount.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletAccount.cs
@@ -1,4 +1,4 @@
-﻿using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
 
 namespace Solana.Unity.Extensions

--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletBalance.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletBalance.cs
@@ -1,4 +1,4 @@
-﻿using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletFilterList.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletFilterList.cs
@@ -1,4 +1,4 @@
-﻿using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Solana.Unity.Extensions/Resources/link.xml
+++ b/src/Solana.Unity.Extensions/Resources/link.xml
@@ -1,0 +1,10 @@
+<linker>
+  
+  <!--Preserve Solana.Unity.Extensions assembly-->
+  
+  <assembly fullname="Solana.Unity.Extensions">
+    <namespace fullname="Solana.Unity.Extensions" preserve="all"/>
+    <type fullname="Solana.Unity.Extensions.*" preserve="all"/>
+  </assembly>
+
+</linker>

--- a/src/Solana.Unity.Extensions/Solana.Unity.Extensions.csproj
+++ b/src/Solana.Unity.Extensions/Solana.Unity.Extensions.csproj
@@ -11,5 +11,11 @@
     <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Solana.Unity.Extensions.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <Import Project="..\..\SharedBuildProperties.props" />
 </Project>

--- a/src/Solana.Unity.Extensions/TokenMintResolver.cs
+++ b/src/Solana.Unity.Extensions/TokenMintResolver.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Solana.Unity.Extensions.TokenMint;
+using Solana.Unity.Extensions.Models.TokenMint;
 using Solana.Unity.Rpc.Core.Http;
 using System;
 using System.Collections.Generic;

--- a/src/Solana.Unity.Extensions/TokenWallet.cs
+++ b/src/Solana.Unity.Extensions/TokenWallet.cs
@@ -7,7 +7,6 @@ using Solana.Unity.Rpc.Models;
 using Solana.Unity.Rpc.Types;
 using Solana.Unity.Extensions.Models;
 using Solana.Unity.Wallet;
-using Solana.Unity.Wallet.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -131,7 +130,7 @@ namespace Solana.Unity.Extensions
         /// <param name="publicKey">The account public key.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>A task that results in an instance of TokenWallet loaded with the token accounts of the publicKey provided.</returns>
-        public async static Task<TokenWallet> LoadAsync(ITokenWalletRpcProxy client,
+        public static async Task<TokenWallet> LoadAsync(ITokenWalletRpcProxy client,
                                                         ITokenMintResolver mintResolver,
                                                         PublicKey publicKey,
                                                         Commitment commitment = Commitment.Finalized)

--- a/src/Solana.Unity.Extensions/WellKnownTokens.cs
+++ b/src/Solana.Unity.Extensions/WellKnownTokens.cs
@@ -1,4 +1,4 @@
-﻿using Solana.Unity.Extensions.TokenMint;
+﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Solana.Unity.Rpc/Resources/link.xml
+++ b/src/Solana.Unity.Rpc/Resources/link.xml
@@ -1,0 +1,10 @@
+<linker>
+  
+  <!--Preserve Solana.Unity.Rpc assembly-->
+  
+  <assembly fullname="Solana.Unity.Rpc">
+    <namespace fullname="Solana.Unity.Rpc" preserve="all"/>
+    <type fullname="Solana.Unity.Rpc.*" preserve="all"/>
+  </assembly>
+
+</linker>

--- a/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
+++ b/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
@@ -20,5 +20,15 @@
     <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Resources" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Solana.Unity.Rpc.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <Import Project="..\..\SharedBuildProperties.props" />
 </Project>

--- a/test/Solana.Unity.Extensions.Test/TokenMintTest.cs
+++ b/test/Solana.Unity.Extensions.Test/TokenMintTest.cs
@@ -1,5 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Solana.Unity.Extensions.TokenMint;
+using Solana.Unity.Extensions.Models.TokenMint;
 using Solana.Unity.Wallet;
 using System.IO;
 

--- a/test/Solana.Unity.Extensions.Test/TokenWalletTest.cs
+++ b/test/Solana.Unity.Extensions.Test/TokenWalletTest.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+using Solana.Unity.Extensions.Models.TokenMint;
 using Solana.Unity.Programs;
 using Solana.Unity.Rpc.Builders;
 using Solana.Unity.Rpc.Messages;
@@ -42,7 +43,7 @@ namespace Solana.Unity.Extensions.Test
 
             // define some mints
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
+            var testToken = new TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
             tokens.Add(testToken);
             Assert.AreEqual(125U, testToken.ConvertDecimalToUlong(1.25M));
             Assert.AreEqual(1.25M, testToken.ConvertUlongToDecimal(125U));
@@ -129,7 +130,7 @@ namespace Solana.Unity.Extensions.Test
 
             // define some mints
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
+            var testToken = new TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
             tokens.Add(testToken);
 
             // load account
@@ -180,7 +181,7 @@ namespace Solana.Unity.Extensions.Test
 
             // define some mints
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
+            var testToken = new TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
             tokens.Add(testToken);
 
             // load account
@@ -219,7 +220,7 @@ namespace Solana.Unity.Extensions.Test
 
             // define some mints
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef(mintPubkey.Key, "TEST", "TEST", 2);
+            var testToken = new TokenDef(mintPubkey.Key, "TEST", "TEST", 2);
             tokens.Add(testToken);
 
             // load account 
@@ -267,7 +268,7 @@ namespace Solana.Unity.Extensions.Test
 
             // define some mints
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
+            var testToken = new TokenDef("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819", "TEST", "TEST", 2);
             tokens.Add(testToken);
 
             // load account and identify test token account with some balance
@@ -293,7 +294,7 @@ namespace Solana.Unity.Extensions.Test
             var client = new MockTokenWalletRpc();
             var mintPubkey = new PublicKey("98mCaWvZYTmTHmimisaAQW4WGLphN1cWhcC7KtnZF819");
             var tokens = new TokenMintResolver();
-            var testToken = new TokenMint.TokenDef(mintPubkey.Key, "TEST", "TEST", 2);
+            var testToken = new TokenDef(mintPubkey.Key, "TEST", "TEST", 2);
             tokens.Add(testToken);
             var ownerWallet = new Wallet.Wallet(MnemonicWords);
 


### PR DESCRIPTION
# Fix Unity code stripping

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | https://github.com/magicblock-labs/Solana.Unity-SDK/issues/69 |

## Problem

Unity was stripping code needed for serialising/deserialising classes used at runtime 

## Solution

Added link.xml to prevent il2cpp compiler to strip classes and replace `IList` with `List`, following suggestion from: https://github.com/JamesNK/Newtonsoft.Json/issues/1521