### PR TITLE
:sparkles: Implement Versioned Transactions

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solana.Unity</Product>
-    <Version>2.6.1.0</Version>
+    <Version>2.6.1.1</Version>
     <Copyright>Copyright 2022 &#169; Magicblock Labs</Copyright>
     <Authors>Magicblock Labs</Authors>
     <PublisherName>Magicblock Labs</PublisherName>

--- a/src/Solana.Unity.Dex/Jupiter/JupiterDex.cs
+++ b/src/Solana.Unity.Dex/Jupiter/JupiterDex.cs
@@ -91,7 +91,7 @@ public class JupiterDexAg: IDexAggregator
             new("inputMint", inputMint.ToString()),
             new("outputMint", outputMint.ToString()),
             new("amount", amount.ToString()),
-            new("asLegacyTransaction", "true")
+            new("asLegacyTransaction", "false")
         };
 
         if (slippageBps.HasValue) queryParams.Add(new KeyValuePair<string, string>("slippageBps", slippageBps.Value.ToString()));
@@ -152,7 +152,7 @@ public class JupiterDexAg: IDexAggregator
             FeeAccount = feeAccount,
             ComputeUnitPriceMicroLamports = computeUnitPriceMicroLamports,
             UseTokenLedger = useTokenLedger,
-            AsLegacyTransaction = true
+            AsLegacyTransaction = false
         };
         
         var requestJson = JsonConvert.SerializeObject(req, _serializerOptions);

--- a/src/Solana.Unity.Rpc/Builders/MessageBuilder.cs
+++ b/src/Solana.Unity.Rpc/Builders/MessageBuilder.cs
@@ -18,17 +18,17 @@ namespace Solana.Unity.Rpc.Builders
         /// <summary>
         /// The length of the block hash.
         /// </summary>
-        private const int BlockHashLength = 32;
+        protected const int BlockHashLength = 32;
 
         /// <summary>
         /// The message header.
         /// </summary>
-        private MessageHeader _messageHeader;
+        protected MessageHeader _messageHeader;
 
         /// <summary>
         /// The account keys list.
         /// </summary>
-        private readonly AccountKeysList _accountKeysList;
+        protected readonly AccountKeysList _accountKeysList;
 
         
         /// <summary>
@@ -40,7 +40,7 @@ namespace Solana.Unity.Rpc.Builders
         /// <summary>
         /// The list of instructions contained within this transaction.
         /// </summary>
-        internal List<TransactionInstruction> Instructions { get; private set; }
+        internal List<TransactionInstruction> Instructions { get; private protected set; }
 
         /// <summary>
         /// The hash of a recent block.
@@ -83,7 +83,7 @@ namespace Solana.Unity.Rpc.Builders
         /// Builds the message into the wire format.
         /// </summary>
         /// <returns>The encoded message.</returns>
-        internal byte[] Build()
+        internal virtual byte[] Build()
         {
             if (RecentBlockHash == null && NonceInformation == null)
                 throw new Exception("recent block hash or nonce information is required");
@@ -119,7 +119,7 @@ namespace Solana.Unity.Rpc.Builders
                     keyIndices[i] = FindAccountIndex(keysList, instruction.Keys[i].PublicKey);
                 }
 
-                CompiledInstruction compiledInstruction = new CompiledInstruction
+                CompiledInstruction compiledInstruction = new()
                 {
                     ProgramIdIndex = FindAccountIndex(keysList, instruction.ProgramId),
                     KeyIndicesCount = ShortVectorEncoding.EncodeLength(keyCount),
@@ -184,7 +184,7 @@ namespace Solana.Unity.Rpc.Builders
         /// Gets the keys for the accounts present in the message.
         /// </summary>
         /// <returns>The list of <see cref="AccountMeta"/>.</returns>
-        private List<AccountMeta> GetAccountKeys()
+        protected List<AccountMeta> GetAccountKeys()
         {
             List<AccountMeta> newList = new();
             var keysList = _accountKeysList.AccountList;
@@ -219,7 +219,7 @@ namespace Solana.Unity.Rpc.Builders
         /// <param name="accountMetas">The <see cref="AccountMeta"/>.</param>
         /// <param name="publicKey">The public key.</param>
         /// <returns>The index of the</returns>
-        private static byte FindAccountIndex(IList<AccountMeta> accountMetas, byte[] publicKey)
+        protected static byte FindAccountIndex(IList<AccountMeta> accountMetas, byte[] publicKey)
         {
             string encodedKey = Encoders.Base58.EncodeData(publicKey);
             return FindAccountIndex(accountMetas, encodedKey);
@@ -231,7 +231,7 @@ namespace Solana.Unity.Rpc.Builders
         /// <param name="accountMetas">The <see cref="AccountMeta"/>.</param>
         /// <param name="publicKey">The public key.</param>
         /// <returns>The index of the</returns>
-        private static byte FindAccountIndex(IList<AccountMeta> accountMetas, string publicKey)
+        protected static byte FindAccountIndex(IList<AccountMeta> accountMetas, string publicKey)
         {
             for (byte index = 0; index < accountMetas.Count; index++)
             {

--- a/src/Solana.Unity.Rpc/Builders/VersionedMessageBuilder.cs
+++ b/src/Solana.Unity.Rpc/Builders/VersionedMessageBuilder.cs
@@ -1,0 +1,134 @@
+using Solana.Unity.Rpc.Models;
+using Solana.Unity.Rpc.Utilities;
+using Solana.Unity.Wallet;
+using Solana.Unity.Wallet.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Solana.Unity.Rpc.Builders
+{
+    /// <summary>
+    /// A compiled instruction within the message.
+    /// </summary>
+    public class VersionedMessageBuilder: MessageBuilder
+    {
+        
+        /// <summary>
+        /// Address Table Lookups
+        /// </summary>
+        public List<MessageAddressTableLookup> AddressTableLookups { get; set; }
+        
+         /// <summary>
+        /// Builds the message into the wire format.
+        /// </summary>
+        /// <returns>The encoded message.</returns>
+        internal override byte[] Build()
+        {
+            if (RecentBlockHash == null && NonceInformation == null)
+                throw new Exception("recent block hash or nonce information is required");
+            if (Instructions == null)
+                throw new Exception("no instructions provided in the transaction");
+
+            // In case the user specified nonce information, we'll use it.
+            if (NonceInformation != null)
+            {
+                RecentBlockHash = NonceInformation.Nonce;
+                _accountKeysList.Add(NonceInformation.Instruction.Keys);
+                _accountKeysList.Add(AccountMeta.ReadOnly(new PublicKey(NonceInformation.Instruction.ProgramId),
+                    false));
+                List<TransactionInstruction> newInstructions = new() { NonceInformation.Instruction };
+                newInstructions.AddRange(Instructions);
+                Instructions = newInstructions;
+            }
+
+            _messageHeader = new MessageHeader();
+
+            List<AccountMeta> keysList = GetAccountKeys();
+            byte[] accountAddressesLength = ShortVectorEncoding.EncodeLength(keysList.Count);
+            int compiledInstructionsLength = 0;
+            List<CompiledInstruction> compiledInstructions = new();
+
+            foreach (TransactionInstruction instruction in Instructions)
+            {
+                int keyCount = instruction.Keys.Count;
+                byte[] keyIndices = new byte[keyCount];
+
+                if (instruction.GetType() == typeof(VersionedTransactionInstruction))
+                {
+                    keyIndices = ((VersionedTransactionInstruction)instruction).KeyIndices;
+                }
+                else
+                {
+                    for (int i = 0; i < keyCount; i++)
+                    {
+                        keyIndices[i] = FindAccountIndex(keysList, instruction.Keys[i].PublicKey);
+                    }
+                }
+
+                CompiledInstruction compiledInstruction = new()
+                {
+                    ProgramIdIndex = FindAccountIndex(keysList, instruction.ProgramId),
+                    KeyIndicesCount = ShortVectorEncoding.EncodeLength(keyIndices.Length),
+                    KeyIndices = keyIndices,
+                    DataLength = ShortVectorEncoding.EncodeLength(instruction.Data.Length),
+                    Data = instruction.Data
+                };
+                compiledInstructions.Add(compiledInstruction);
+                compiledInstructionsLength += compiledInstruction.Length();
+            }
+
+            int accountKeysBufferSize = _accountKeysList.AccountList.Count * 32;
+            MemoryStream accountKeysBuffer = new MemoryStream(accountKeysBufferSize);
+            byte[] instructionsLength = ShortVectorEncoding.EncodeLength(compiledInstructions.Count);
+
+            foreach (AccountMeta accountMeta in keysList)
+            {
+                accountKeysBuffer.Write(accountMeta.PublicKeyBytes, 0, accountMeta.PublicKeyBytes.Length);
+                if (accountMeta.IsSigner)
+                {
+                    _messageHeader.RequiredSignatures += 1;
+                    if (!accountMeta.IsWritable)
+                        _messageHeader.ReadOnlySignedAccounts += 1;
+                }
+                else
+                {
+                    if (!accountMeta.IsWritable)
+                        _messageHeader.ReadOnlyUnsignedAccounts += 1;
+                }
+            }
+
+            #region Build Message Body
+
+            int messageBufferSize = MessageHeader.Layout.HeaderLength + BlockHashLength +
+                                    accountAddressesLength.Length +
+                                    +instructionsLength.Length + compiledInstructionsLength + accountKeysBufferSize;
+            MemoryStream buffer = new MemoryStream(messageBufferSize);
+            byte[] messageHeaderBytes = _messageHeader.ToBytes();
+
+            buffer.Write(new byte[] { 128 }, 0, 1);
+            buffer.Write(messageHeaderBytes, 0, messageHeaderBytes.Length);
+            buffer.Write(accountAddressesLength, 0, accountAddressesLength.Length);
+            buffer.Write(accountKeysBuffer.ToArray(), 0, accountKeysBuffer.ToArray().Length);
+            var encodedRecentBlockHash = Encoders.Base58.DecodeData(RecentBlockHash);
+            buffer.Write(encodedRecentBlockHash, 0, encodedRecentBlockHash.Length);
+            buffer.Write(instructionsLength, 0, instructionsLength.Length);
+
+            foreach (CompiledInstruction compiledInstruction in compiledInstructions)
+            {
+                buffer.WriteByte(compiledInstruction.ProgramIdIndex);
+                buffer.Write(compiledInstruction.KeyIndicesCount, 0, compiledInstruction.KeyIndicesCount.Length);
+                buffer.Write(compiledInstruction.KeyIndices, 0, compiledInstruction.KeyIndices.Length);
+                buffer.Write(compiledInstruction.DataLength, 0, compiledInstruction.DataLength.Length);
+                buffer.Write(compiledInstruction.Data, 0, compiledInstruction.Data.Length);
+            }
+
+            #endregion
+
+            var serializeAddressTableLookups = AddressTableLookupUtils.SerializeAddressTableLookups(AddressTableLookups);
+            buffer.Write(serializeAddressTableLookups, 0, serializeAddressTableLookups.Length);
+
+            return buffer.ToArray();
+        }
+    }
+}

--- a/src/Solana.Unity.Rpc/Core/Http/CrossHttpClient.cs
+++ b/src/Solana.Unity.Rpc/Core/Http/CrossHttpClient.cs
@@ -13,7 +13,7 @@ namespace Solana.Unity.Rpc.Core.Http;
 /// </summary>
 public static class CrossHttpClient
 {
-    private static TaskCompletionSource<UnityWebRequest.Result> _currentRequestTask;
+    //private static TaskCompletionSource<UnityWebRequest.Result> _currentRequestTask;
 
     /// <summary>
     /// Send an async request using HttpClient or UnityWebRequest if running on Unity
@@ -50,10 +50,10 @@ public static class CrossHttpClient
                 request.SetRequestHeader("Content-Type", "application/json");
             }
             request.downloadHandler = new DownloadHandlerBuffer();
-            if (_currentRequestTask != null)
-            {
-                await _currentRequestTask.Task;
-            }
+            // if (_currentRequestTask != null)
+            // {
+            //     await _currentRequestTask.Task;
+            // }
             UnityWebRequest.Result result = await SendRequest(request);
         
             if (result == UnityWebRequest.Result.Success)
@@ -70,8 +70,8 @@ public static class CrossHttpClient
         {
             response.Content = new StringContent("Error: " + e.Message);
             response.StatusCode = HttpStatusCode.ExpectationFailed;
-            _currentRequestTask?.TrySetException(e);
-            _currentRequestTask = null;
+            // _currentRequestTask?.TrySetException(e);
+            // _currentRequestTask = null;
         }
         return response;
     }
@@ -81,7 +81,7 @@ public static class CrossHttpClient
         TaskCompletionSource<UnityWebRequest.Result> sendRequestTask = new();
         try
         {
-            _currentRequestTask = sendRequestTask;
+            //_currentRequestTask = sendRequestTask;
             UnityWebRequestAsyncOperation op = request.SendWebRequest();
 
             if (request.isDone)
@@ -107,8 +107,8 @@ public static class CrossHttpClient
         catch (Exception ex)
         {
             sendRequestTask.TrySetException(ex);
-            _currentRequestTask.SetException(ex);
-            _currentRequestTask = null;
+            // _currentRequestTask.SetException(ex);
+            // _currentRequestTask = null;
         }
         return sendRequestTask.Task;
     }

--- a/src/Solana.Unity.Rpc/Models/AccountKeysList.cs
+++ b/src/Solana.Unity.Rpc/Models/AccountKeysList.cs
@@ -7,7 +7,7 @@ namespace Solana.Unity.Rpc.Models
     /// A wrapper around a list of <see cref="AccountMeta"/>s that takes care of deduplication and ordering according to 
     /// the wire format specification.
     /// </summary>
-    internal class AccountKeysList
+    public class AccountKeysList
     {
         /// <summary>
         /// The account metas list.

--- a/src/Solana.Unity.Rpc/Models/Message.cs
+++ b/src/Solana.Unity.Rpc/Models/Message.cs
@@ -154,6 +154,13 @@ namespace Solana.Unity.Rpc.Models
         /// <returns>The Message object instance.</returns>
         public static Message Deserialize(ReadOnlySpan<byte> data)
         {
+            // Check that the message is not a VersionedMessage
+            byte prefix = data[0];
+            byte maskedPrefix = (byte)(prefix & VersionedMessage.VersionPrefixMask);
+            if(prefix != maskedPrefix)
+                throw new NotSupportedException("The message is a VersionedMessage, use VersionedMessage." +
+                                                    "Deserialize instead.");
+            
             // Read message header
             byte numRequiredSignatures = data[MessageHeader.Layout.RequiredSignaturesOffset];
             byte numReadOnlySignedAccounts = data[MessageHeader.Layout.ReadOnlySignedAccountsOffset];

--- a/src/Solana.Unity.Rpc/Models/VersionedMessage.cs
+++ b/src/Solana.Unity.Rpc/Models/VersionedMessage.cs
@@ -1,0 +1,253 @@
+using Solana.Unity.Rpc.Utilities;
+using Solana.Unity.Wallet;
+using Solana.Unity.Wallet.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Solana.Unity.Rpc.Models
+{
+
+    /// <summary>
+    /// Represents the Message of a Solana <see cref="Transaction"/>.
+    /// </summary>
+    public class VersionedMessage: Message
+    {
+        /// <summary>
+        /// Version prefix Mask.
+        /// </summary>
+        public const byte VersionPrefixMask = 0x7F;
+
+        /// <summary>
+        /// Address table lookup
+        /// </summary>
+        public List<MessageAddressTableLookup> AddressTableLookups { get; set; }
+
+
+        /// <summary>
+        /// Deserialize a compiled message into a Message object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Message object.</param>
+        /// <returns>The Message object instance.</returns>
+        public static new VersionedMessage Deserialize(ReadOnlySpan<byte> data)
+        {
+            byte prefix = data[0];
+            byte maskedPrefix = (byte)(prefix & VersionPrefixMask);
+            
+            if(prefix == maskedPrefix)
+                throw new NotSupportedException("Expected versioned message but received legacy message");
+            
+            byte version = maskedPrefix;
+            
+            if(version != 0)
+                throw new NotSupportedException($"Expected versioned message with version 0 but found version {version}");
+            
+            data = data.Slice(1, data.Length - 1); // Remove the processed prefix byte
+            
+            // Read message header
+            byte numRequiredSignatures = data[MessageHeader.Layout.RequiredSignaturesOffset];
+            byte numReadOnlySignedAccounts = data[MessageHeader.Layout.ReadOnlySignedAccountsOffset];
+            byte numReadOnlyUnsignedAccounts = data[MessageHeader.Layout.ReadOnlyUnsignedAccountsOffset];
+
+            // Read account keys
+            (int accountAddressLength, int accountAddressLengthEncodedLength) =
+                ShortVectorEncoding.DecodeLength(data.Slice(MessageHeader.Layout.HeaderLength,
+                    ShortVectorEncoding.SpanLength));
+            List<PublicKey> accountKeys = new(accountAddressLength);
+            for (int i = 0; i < accountAddressLength; i++)
+            {
+                ReadOnlySpan<byte> keyBytes = data.Slice(
+                    MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                    i * PublicKey.PublicKeyLength,
+                    PublicKey.PublicKeyLength);
+                accountKeys.Add(new PublicKey(keyBytes));
+            }
+
+            // Read block hash
+            string blockHash =
+                Encoders.Base58.EncodeData(data.Slice(
+                    MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                    accountAddressLength * PublicKey.PublicKeyLength,
+                    PublicKey.PublicKeyLength).ToArray());
+
+            // Read the number of instructions in the message
+            (int instructionsLength, int instructionsLengthEncodedLength) =
+                ShortVectorEncoding.DecodeLength(
+                    data.Slice(
+                        MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                        (accountAddressLength * PublicKey.PublicKeyLength) + PublicKey.PublicKeyLength,
+                        ShortVectorEncoding.SpanLength));
+
+            List<CompiledInstruction> instructions = new(instructionsLength);
+            int instructionsOffset =
+                MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                (accountAddressLength * PublicKey.PublicKeyLength) + PublicKey.PublicKeyLength +
+                instructionsLengthEncodedLength;
+            ReadOnlySpan<byte> instructionsData = data[instructionsOffset..];
+
+            int instructionsDataLength = 0;
+
+            // Read the instructions in the message
+            for (int i = 0; i < instructionsLength; i++)
+            {
+                (CompiledInstruction compiledInstruction, int instructionLength) =
+                    CompiledInstruction.Deserialize(instructionsData);
+                instructions.Add(compiledInstruction);
+                instructionsData = instructionsData[instructionLength..];
+                instructionsDataLength += instructionLength;
+            }
+            
+            // Read the address table lookups
+            int tableLookupOffset =
+                MessageHeader.Layout.HeaderLength + accountAddressLengthEncodedLength +
+                (accountAddressLength * PublicKey.PublicKeyLength) + PublicKey.PublicKeyLength +
+                instructionsLengthEncodedLength + instructionsDataLength;
+            
+            ReadOnlySpan<byte> tableLookupData = data[tableLookupOffset..];
+            
+            (int addressTableLookupsCount, int addressTableLookupsEncodedCount) = ShortVectorEncoding.DecodeLength(tableLookupData);
+            List<MessageAddressTableLookup> addressTableLookups = new();
+            tableLookupData = tableLookupData[addressTableLookupsEncodedCount..];
+            
+            for (int i = 0; i < addressTableLookupsCount; i++)
+            {
+                byte[] accountKeyBytes = tableLookupData.Slice(0, PublicKey.PublicKeyLength).ToArray();
+                PublicKey accountKey = new(accountKeyBytes);
+                tableLookupData = tableLookupData.Slice(PublicKey.PublicKeyLength);
+
+                (int writableIndexesLength, int writableIndexesEncodedLength) = ShortVectorEncoding.DecodeLength(tableLookupData);
+                List<byte> writableIndexes = tableLookupData.Slice(writableIndexesEncodedLength, writableIndexesLength).ToArray().ToList();
+                tableLookupData = tableLookupData.Slice(writableIndexesEncodedLength + writableIndexesLength);
+
+                (int readonlyIndexesLength, int readonlyIndexesEncodedLength) = ShortVectorEncoding.DecodeLength(tableLookupData);
+                List<byte> readonlyIndexes = tableLookupData.Slice(readonlyIndexesEncodedLength, readonlyIndexesLength).ToArray().ToList();
+                tableLookupData = tableLookupData.Slice(readonlyIndexesEncodedLength + readonlyIndexesLength);
+
+                addressTableLookups.Add(new MessageAddressTableLookup
+                {
+                    AccountKey = accountKey,
+                    WritableIndexes = writableIndexes.ToArray(),
+                    ReadonlyIndexes = readonlyIndexes.ToArray()
+                });
+            }
+
+            return new VersionedMessage()
+            {
+                Header = new MessageHeader()
+                {
+                    RequiredSignatures = numRequiredSignatures,
+                    ReadOnlySignedAccounts = numReadOnlySignedAccounts,
+                    ReadOnlyUnsignedAccounts = numReadOnlyUnsignedAccounts
+                },
+                RecentBlockhash = blockHash,
+                AccountKeys = accountKeys,
+                Instructions = instructions,
+                AddressTableLookups = addressTableLookups
+            };
+        }
+        
+        /// <summary>
+        /// Deserialize a compiled message encoded as base-64 into a Message object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Message object.</param>
+        /// <returns>The Transaction object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given string is null.</exception>
+        public static new VersionedMessage Deserialize(string data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            byte[] decodedBytes;
+
+            try
+            {
+                decodedBytes = Convert.FromBase64String(data);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("could not decode message data from base64", ex);
+            }
+
+            return Deserialize(decodedBytes);
+        }
+
+        /// <summary>
+        /// Deserialize the message version
+        /// </summary>
+        /// <param name="serializedMessage"></param>
+        /// <returns></returns>
+        public static string DeserializeMessageVersion(byte[] serializedMessage)
+        {
+            byte prefix = serializedMessage[0];
+            byte maskedPrefix = (byte)(prefix & VersionPrefixMask);
+
+            // If the highest bit of the prefix is not set, the message is not versioned
+            if (maskedPrefix == prefix)
+            {
+                return "legacy";
+            }
+
+            // The lower 7 bits of the prefix indicate the message version
+            return maskedPrefix.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Message Address Lookup table
+    /// </summary>
+    public class MessageAddressTableLookup
+    {
+        /// <summary>
+        /// Account Key
+        /// </summary>
+        public PublicKey AccountKey { get; set; }
+
+        /// <summary>
+        /// Writable indexes
+        /// </summary>
+        public byte[] WritableIndexes { get; set; }
+
+        /// <summary>
+        /// Read only indexes
+        /// </summary>
+        public byte[] ReadonlyIndexes { get; set; }
+    }
+    
+    /// <summary>
+    /// Message Address Lookup table
+    /// </summary>
+    public static class AddressTableLookupUtils
+    {
+        /// <summary>
+        /// Serialize the address table lookups
+        /// </summary>
+        /// <param name="addressTableLookups"></param>
+        /// <returns></returns>
+        public static byte[] SerializeAddressTableLookups(List<MessageAddressTableLookup> addressTableLookups)
+        {
+            MemoryStream buffer = new();
+            
+            var encodedAddressTableLookupsLength = ShortVectorEncoding.EncodeLength(addressTableLookups.Count);
+            buffer.Write(encodedAddressTableLookupsLength, 0, encodedAddressTableLookupsLength.Length);
+
+            foreach (var lookup in addressTableLookups)
+            {
+                // Write the Account Key
+                buffer.Write(lookup.AccountKey, 0, PublicKey.PublicKeyLength);
+                
+                // Write the Writable Indexes
+                var encodedWritableIndexesLength = ShortVectorEncoding.EncodeLength(lookup.WritableIndexes.Length);
+                buffer.Write(encodedWritableIndexesLength, 0, encodedWritableIndexesLength.Length);
+                buffer.Write(lookup.WritableIndexes, 0, lookup.WritableIndexes.Length);
+                
+                // Write the Readonly Indexes
+                var encodedReadonlyIndexesLength = ShortVectorEncoding.EncodeLength(lookup.ReadonlyIndexes.Length);
+                buffer.Write(encodedReadonlyIndexesLength, 0, encodedReadonlyIndexesLength.Length);
+                buffer.Write(lookup.ReadonlyIndexes, 0, lookup.ReadonlyIndexes.Length);
+            }
+
+            return buffer.ToArray();
+        }
+    }
+}

--- a/src/Solana.Unity.Rpc/Models/VersionedTransaction.cs
+++ b/src/Solana.Unity.Rpc/Models/VersionedTransaction.cs
@@ -1,0 +1,166 @@
+using Solana.Unity.Rpc.Builders;
+using Solana.Unity.Rpc.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Solana.Unity.Rpc.Models
+{
+
+    /// <summary>
+    /// Represents a Transaction in Solana.
+    /// </summary>
+    public class VersionedTransaction: Transaction
+    {
+        
+        /// <summary>
+        /// Address Table Lookups
+        /// </summary>
+        public List<MessageAddressTableLookup> AddressTableLookups { get; set; }
+
+
+        /// <summary>
+        /// Compile the transaction data.
+        /// </summary>
+        public override byte[] CompileMessage()
+        {
+            VersionedMessageBuilder messageBuilder = new() { FeePayer = FeePayer, AccountKeys = _accountKeys };
+
+            if (RecentBlockHash != null) messageBuilder.RecentBlockHash = RecentBlockHash;
+            if (NonceInformation != null) messageBuilder.NonceInformation = NonceInformation;
+
+            foreach (TransactionInstruction instruction in Instructions)
+            {
+                messageBuilder.AddInstruction(instruction);
+            }
+
+            messageBuilder.AddressTableLookups = AddressTableLookups;
+            
+            return messageBuilder.Build();
+        }
+
+        /// <summary>
+        /// Populate the Transaction from the given message and signatures.
+        /// </summary>
+        /// <param name="message">The <see cref="Message"/> object.</param>
+        /// <param name="signatures">The list of signatures.</param>
+        /// <returns>The Transaction object.</returns>
+        public static VersionedTransaction Populate(VersionedMessage message, IList<byte[]> signatures = null)
+        {
+            VersionedTransaction tx = new()
+            {
+                RecentBlockHash = message.RecentBlockhash,
+                Signatures = new List<SignaturePubKeyPair>(),
+                Instructions = new List<TransactionInstruction>(),
+                AddressTableLookups = message.AddressTableLookups,
+                _accountKeys = message.AccountKeys
+            };
+
+            if (message.Header.RequiredSignatures > 0)
+            {
+                tx.FeePayer = message.AccountKeys[0];
+            }
+
+            if (signatures != null)
+            {
+                for (int i = 0; i < signatures.Count; i++)
+                {
+                    tx.Signatures.Add(new SignaturePubKeyPair
+                    {
+                        PublicKey = message.AccountKeys[i],
+                        Signature = signatures[i]
+                    });
+                }
+            }
+
+            for (int i = 0; i < message.Instructions.Count; i++)
+            {
+                CompiledInstruction compiledInstruction = message.Instructions[i];
+                (int accountLength, _) = ShortVectorEncoding.DecodeLength(compiledInstruction.KeyIndicesCount);
+
+                List<AccountMeta> accounts = new(accountLength);
+                for (int j = 0; j < accountLength; j++)
+                {
+                    int k = compiledInstruction.KeyIndices[j];
+                    if(k >= message.AccountKeys.Count) continue;
+                        accounts.Add(new AccountMeta(message.AccountKeys[k], message.IsAccountWritable(k),
+                        tx.Signatures.Any(pair => pair.PublicKey.Key == message.AccountKeys[k].Key) || message.IsAccountSigner(k)));
+                }
+
+                VersionedTransactionInstruction instruction = new()
+                {
+                    Keys = accounts,
+                    KeyIndices = compiledInstruction.KeyIndices,
+                    ProgramId = message.AccountKeys[compiledInstruction.ProgramIdIndex],
+                    Data = compiledInstruction.Data
+                };
+                if (i == 0 && accounts.Any(a => a.PublicKey == "SysvarRecentB1ockHashes11111111111111111111"))
+                {
+                    tx.NonceInformation = new NonceInformation { Instruction = instruction, Nonce = tx.RecentBlockHash };
+                    continue;
+                }
+                tx.Instructions.Add(instruction);
+            }
+
+            return tx;
+        }
+
+        /// <summary>
+        /// Populate the Transaction from the given compiled message and signatures.
+        /// </summary>
+        /// <param name="message">The compiled message, as base-64 encoded string.</param>
+        /// <param name="signatures">The list of signatures.</param>
+        /// <returns>The Transaction object.</returns>
+        public static new VersionedTransaction Populate(string message, IList<byte[]> signatures = null)
+            => Populate(VersionedMessage.Deserialize(message), signatures);
+
+        /// <summary>
+        /// Deserialize a wire format transaction into a Transaction object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Transaction object.</param>
+        /// <returns>The Transaction object.</returns>
+        public static new VersionedTransaction Deserialize(ReadOnlySpan<byte> data)
+        {
+            // Read number of signatures
+            (int signaturesLength, int encodedLength) =
+                ShortVectorEncoding.DecodeLength(data[..ShortVectorEncoding.SpanLength]);
+            List<byte[]> signatures = new(signaturesLength);
+
+            for (int i = 0; i < signaturesLength; i++)
+            {
+                ReadOnlySpan<byte> signature =
+                    data.Slice(encodedLength + (i * TransactionBuilder.SignatureLength),
+                        TransactionBuilder.SignatureLength);
+                signatures.Add(signature.ToArray());
+            }
+
+            var message = VersionedMessage.Deserialize(data[(encodedLength + (signaturesLength * TransactionBuilder.SignatureLength))..]);
+            return Populate(message, signatures);
+        }
+
+        /// <summary>
+        /// Deserialize a transaction encoded as base-64 into a Transaction object.
+        /// </summary>
+        /// <param name="data">The data to deserialize into the Transaction object.</param>
+        /// <returns>The Transaction object.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given string is null.</exception>
+        public static new VersionedTransaction Deserialize(string data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            byte[] decodedBytes;
+
+            try
+            {
+                decodedBytes = Convert.FromBase64String(data);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("could not decode transaction data from base64", ex);
+            }
+
+            return Deserialize(decodedBytes);
+        }
+    }
+}

--- a/src/Solana.Unity.Rpc/Models/VersionedTransactionInstruction.cs
+++ b/src/Solana.Unity.Rpc/Models/VersionedTransactionInstruction.cs
@@ -1,0 +1,13 @@
+namespace Solana.Unity.Rpc.Models
+{
+    /// <summary>
+    /// Represents a versioned transaction instruction before being compiled into the transaction's message.
+    /// </summary>
+    public class VersionedTransactionInstruction : TransactionInstruction
+    {
+        /// <summary>
+        /// The keys associated with the instruction.
+        /// </summary>
+        public byte[] KeyIndices { get; init; }
+    }
+}

--- a/test/Solana.Unity.Dex.Test/Jupiter/Integration/JupiterTests.cs
+++ b/test/Solana.Unity.Dex.Test/Jupiter/Integration/JupiterTests.cs
@@ -3,6 +3,9 @@ using Solana.Unity.Dex.Jupiter;
 using Solana.Unity.Dex.Models;
 using System.Threading.Tasks;
 using Solana.Unity.Dex.Test.Orca;
+using Solana.Unity.Rpc;
+using Solana.Unity.Rpc.Models;
+using Solana.Unity.Rpc.Types;
 using Solana.Unity.Wallet;
 using System.Collections.Generic;
 using System.Linq;
@@ -86,5 +89,6 @@ namespace Solana.Unity.Dex.Test.Jupiter.Integration
             Assert.IsTrue(token.Mint.Equals(orcaMint));
             Assert.IsTrue(token.Symbol.Equals("ORCA"));
         }
+        
     }
 }

--- a/test/Solana.Unity.Rpc.Test/VersionedMessageTest.cs
+++ b/test/Solana.Unity.Rpc.Test/VersionedMessageTest.cs
@@ -1,0 +1,37 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Solana.Unity.Rpc.Models;
+using System;
+
+namespace Solana.Unity.Rpc.Test
+{
+    [TestClass]
+    public class VersionedMessageTest
+    {
+        [TestMethod]
+        public void DeserializeMessageVersion()
+        {
+            // Buffer with legacy prefix
+            byte[] bufferWithLegacyPrefix = new byte[] { 1 };
+            Assert.AreEqual("legacy", VersionedMessage.DeserializeMessageVersion(bufferWithLegacyPrefix));
+
+            // Buffer with version prefixes
+            byte[] bufferWithVersionPrefix;
+            for (byte version = 0; version <= 127; version++)
+            {
+                bufferWithVersionPrefix = new byte[] { (byte)(1 << 7 | version) };
+                Assert.AreEqual(version.ToString(), VersionedMessage.DeserializeMessageVersion(bufferWithVersionPrefix));
+            }
+        }
+        
+        [TestMethod]
+        public void DeserializeFailure()
+        {
+            byte[] bufferWithV1Prefix = new byte[] { (byte)(1 << 7 | 1) };
+
+            Assert.ThrowsException<NotSupportedException>(() =>
+            {
+                VersionedMessage.Deserialize(bufferWithV1Prefix);
+            });
+        }
+    }
+}

--- a/test/Solana.Unity.Rpc.Test/VersionedTransactionTest.cs
+++ b/test/Solana.Unity.Rpc.Test/VersionedTransactionTest.cs
@@ -1,0 +1,60 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Solana.Unity.Rpc.Models;
+using Solana.Unity.Wallet;
+using System;
+using System.Collections.Generic;
+
+namespace Solana.Unity.Rpc.Test
+{
+    [TestClass]
+    public class VersionedTransactionTest
+    {
+        // Text Fixtures
+        private const string Base64SerializedVersionedTx = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAID0PC8escBdHr+DqWKtpHK7G3Pjdg2Ck7knmE3xgnbQOjdjA4EKgxNXOjIIkHRHfkut/Vvp8rP22jsbUgEwuWYySfUxeumK36JBIaYA4PqEKsw0TjomhTo8daZDNy5TKRyKIdmklnVTL3GrXKI61rcFwE4jsO/6OYROzRbst6fL4CvWac4W46kaGG3DB/ybn8y3wbxeSOBMe+ys/dGPs7iqjfsLhf7Ff9NofcPgIyAbMytm5ggTyKwmR+JqgXUXARVfJea6+zakfoAfAfG3uw1Hd6+x+V6Sy31FQ0u6YV9iBFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAAAR51VvyMcBu7nTFbs5oFQf9sbLeo/SOUQKxzaJWvBOPBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqU9LbA5BCP0qaiR46uCsxZ2yG7Tt9RHBYs9gLR4MCQH7jJclj04kifG7PRApFI4NgwtaE5na/xCEBI572Nvp+Fm0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6LMkU+jQNMN+ACdixGmE5BkdVUZx1+dwwNeMrT47LC3ZBwgABQLAXBUADQYABAAKBwsBAQcCAAQMAgAAAADh9QUAAAAACwEEARENBgACACIHCwEBCTMLDAAEAwUCCiIJCQ4JHwsMHgMZBRwbGh0mHwsMGAMXARYVFAYlIyAhDAEFEhMREAskJA8uwSCbM0HWnIEHAwAAABEBRgADEQEeAAIJZAIDAOH1BQAAAACIDRwAAAAAADIAAAsDBAAAAQkDnKEf7dZ6lPW72wJ6PGEMo6GObunTTrduTS0+A/SoNtQFzcnIxscGAMTF6GXLuwkpzcAg7dDeOseRGYg4EsfNop9xrUgbIpA5iAsD3kEFIB8dHBsBIaPIqiSwTwiZiBypIhYrNygPC7k5xWLT/nfZXo4VmqMKBmJlZGNmYQFn";
+        private const string VersionedCompiledMessage = "gAEACA9DwvHrHAXR6/g6liraRyuxtz43YNgpO5J5hN8YJ20Do3YwOBCoMTVzoyCJB0R35Lrf1b6fKz9to7G1IBMLlmMkn1MXrpit+iQSGmAOD6hCrMNE46JoU6PHWmQzcuUykciiHZpJZ1Uy9xq1yiOta3BcBOI7Dv+jmETs0W7Leny+Ar1mnOFuOpGhhtwwf8m5/Mt8G8XkjgTHvsrP3Rj7O4qo37C4X+xX/TaH3D4CMgGzMrZuYIE8isJkfiaoF1FwEVXyXmuvs2pH6AHwHxt7sNR3evsflekst9RUNLumFfYgRQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKlPS2wOQQj9KmokeOrgrMWdshu07fURwWLPYC0eDAkB+4yXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZtD/6J/XX9kp0wJsfKVh53ksJqzbfyd1RSzIap7OM5eizJFPo0DTDfgAnYsRphOQZHVVGcdfncMDXjK0+Oywt2QcIAAUCwFwVAA0GAAQACgcLAQEHAgAEDAIAAAAA4fUFAAAAAAsBBAERDQYAAgAiBwsBAQkzCwwABAMFAgoiCQkOCR8LDB4DGQUcGxodJh8LDBgDFwEWFRQGJSMgIQwBBRITERALJCQPLsEgmzNB1pyBBwMAAAARAUYAAxEBHgACCWQCAwDh9QUAAAAAiA0cAAAAAAAyAAALAwQAAAEJA5yhH+3WepT1u9sCejxhDKOhjm7p0063bk0tPgP0qDbUBc3JyMbHBgDExehly7sJKc3AIO3Q3jrHkRmIOBLHzaKfca1IGyKQOYgLA95BBSAfHRwbASGjyKoksE8ImYgcqSIWKzcoDwu5OcVi0/532V6OFZqjCgZiZWRjZmEBZw==";
+        private const string TxSignature = "FdaS+HGFi7gVXum3hQ2Sb3SRog7Dy+wWmYxMR3PrO+neBtLutfEa4gWLmPUNNsx1zPy3+yC8HRug1YgEsS3PDQ==";
+        private readonly Wallet.Wallet _testWallet = new(new PrivateKey("4j3PbCCYvcAz1FbKGs7fBoQ5cd8piWCsQm5k6wNnTTzEtE6aM8JZ2AJaaJTjZJgGk9LywyonNHcVopHAwrMqh6kr").KeyBytes, "", SeedMode.Bip39);
+
+        
+        [TestMethod]
+        public void DeserializeVersionedTransactions()
+        {
+            // Deserialize the versioned transaction
+            Transaction versionedTx = Transaction.Deserialize(Base64SerializedVersionedTx);
+            
+            // Assert that the transaction was deserialized correctly using VersionedTransaction class
+            Assert.IsNotNull(versionedTx);
+            Assert.IsNotNull(((VersionedTransaction)versionedTx).AddressTableLookups);
+            Assert.AreEqual(((VersionedTransaction)versionedTx).AddressTableLookups.Count, 3);
+            
+            // Assert that the message is the same as the expected compiled message
+            var message = versionedTx.CompileMessage();
+            CollectionAssert.AreEqual( Convert.FromBase64String(VersionedCompiledMessage), message);
+        }
+        
+        [TestMethod]
+        public void DeserializeSerializeVersionedTransactions()
+        {
+            // Deserialize the versioned transaction
+            Transaction versionedTx = Transaction.Deserialize(Base64SerializedVersionedTx);
+            Assert.IsNotNull(versionedTx);
+            
+            // Serialize the versioned transaction
+            var serializedVersionedTx = versionedTx.Serialize();
+            Assert.AreEqual(Base64SerializedVersionedTx, Convert.ToBase64String(serializedVersionedTx));
+        }
+        
+        [TestMethod]
+        public void TestSignVersionedTransactions()
+        {
+            // Deserialize the versioned transaction
+            Transaction versionedTx = Transaction.Deserialize(Base64SerializedVersionedTx);
+            Assert.IsNotNull(versionedTx);
+
+            // Check that the signature is as expected
+            versionedTx.Signatures = new List<SignaturePubKeyPair>();
+            versionedTx.Sign(_testWallet.Account);
+            Assert.AreEqual(TxSignature, Convert.ToBase64String(versionedTx.Signatures[0].Signature));
+        }
+    }
+}


### PR DESCRIPTION
# Implement Versioned Transactions

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | #43 |

## Problem

- [Versioned Transactions](https://docs.solana.com/developing/versioned-transactions) were not supported, see issue #43

## Solution

- Added a VersionedTransaction class which can serialize/deserialize [Versioned Transactions](https://docs.solana.com/developing/versioned-transactions), implemented following web3.js [implementation](https://github.com/solana-labs/solana-web3.js/blob/master/packages/library-legacy/src/transaction/versioned.ts) 
- VersionedTransaction contains the `AddressTableLookups`
- `Transaction.Deserialize` use the prefix byte to auto-detected if the transaction is legacy or versioned and uses the correct implementation