### PR TITLE
:sparkles: Add SwapMode to allow ExactOut mode with Jupiter

### DIFF
--- a/src/Solana.Unity.Dex/IDexAggregator.cs
+++ b/src/Solana.Unity.Dex/IDexAggregator.cs
@@ -19,13 +19,13 @@ namespace Solana.Unity.Dex
     /// </remarks>
     public interface IDexAggregator
     {
-        
         /// <summary> 
         /// Creates a quote for a swap for a specified pair of input/output token mint. 
         /// </summary> 
         /// <param name="inputMint">The mint address of the input token (the token to swap).</param> 
         /// <param name="outputMint">The mint address of the output token (the token to swap for).</param> 
-        /// <param name="amount">The amount to swap (could be of the input token or output token).</param> 
+        /// <param name="amount">The amount to swap (could be of the input token or output token).</param>
+        /// <param name="swapMode">The swap mode. ExactIn or ExactOut</param>
         /// <param name="slippageBps">The slippage % in BPS. If the output token amount exceeds the slippage then the swap transaction will fail.</param> 
         /// <param name="excludeDexes">Default is that all DEXes are included. You can pass in the DEXes that you want to exclude and separate them by ,. For example, Aldrin,Saber.</param> 
         /// <param name="onlyDirectRoutes">Default is false. Direct Routes limits Jupiter routing to single hop routes only.</param> 
@@ -36,6 +36,7 @@ namespace Solana.Unity.Dex
             PublicKey inputMint,
             PublicKey outputMint,
             BigInteger amount,
+            SwapMode swapMode = SwapMode.ExactIn,
             ushort? slippageBps = null,
             List<string> excludeDexes = null,
             bool onlyDirectRoutes = false,

--- a/src/Solana.Unity.Dex/Jupiter/JupiterDex.cs
+++ b/src/Solana.Unity.Dex/Jupiter/JupiterDex.cs
@@ -1,7 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Solana.Unity.Dex.Jupiter.Core.Types;
 using Solana.Unity.Dex.Jupiter.Core.Types.Http;
 using Solana.Unity.Dex.Models;
 using Solana.Unity.Dex.Orca.Orca;
@@ -79,6 +78,7 @@ public class JupiterDexAg: IDexAggregator
         PublicKey inputMint,
         PublicKey outputMint,
         BigInteger amount,
+        SwapMode swapMode = SwapMode.ExactIn,
         ushort? slippageBps = null,
         List<string> excludeDexes = null,
         bool onlyDirectRoutes = false,
@@ -91,6 +91,7 @@ public class JupiterDexAg: IDexAggregator
             new("inputMint", inputMint.ToString()),
             new("outputMint", outputMint.ToString()),
             new("amount", amount.ToString()),
+            new("swapMode", swapMode.ToString()),
             new("asLegacyTransaction", "false")
         };
 

--- a/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
+++ b/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
@@ -25,6 +25,6 @@
     
     <PropertyGroup>
     <Product>Solana.Unity.Dex</Product>
-    <Version>1.2</Version>
+    <Version>1.3</Version>
     </PropertyGroup>
 </Project>

--- a/test/Solana.Unity.Dex.Test/Jupiter/Integration/JupiterTests.cs
+++ b/test/Solana.Unity.Dex.Test/Jupiter/Integration/JupiterTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Solana.Unity.Dex.Jupiter;
 using Solana.Unity.Dex.Models;
+using Solana.Unity.Dex.Quotes;
 using System.Threading.Tasks;
 using Solana.Unity.Dex.Test.Orca;
 using Solana.Unity.Rpc;
@@ -30,6 +31,25 @@ namespace Solana.Unity.Dex.Test.Jupiter.Integration
             BigInteger amount = 100000000;
             
             var quote = await dexAg.GetSwapQuote(inputMint, outputMint, amount);
+            
+            Assert.IsNotNull(quote);
+            Assert.IsTrue(quote.OutputAmount > 0);
+            Assert.IsTrue(quote.InputAmount > 0);
+            Assert.IsTrue(quote.RoutePlan.Count > 0);
+        }
+        
+        
+        [Test] 
+        [Description("get a swap quote")]
+        public static async Task GetSwapQuoteWithExactOut()
+        {
+            IDexAggregator dexAg = new JupiterDexAg(TestConfiguration.TestWallet.Account);
+
+            PublicKey inputMint = new("So11111111111111111111111111111111111111112"); // SOL
+            PublicKey outputMint = new("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"); // USDC
+            BigInteger amount = 100;
+            
+            var quote = await dexAg.GetSwapQuote(inputMint, outputMint, amount, SwapMode.ExactOut);
             
             Assert.IsNotNull(quote);
             Assert.IsTrue(quote.OutputAmount > 0);


### PR DESCRIPTION
# Add SwapMode to allow ExactOut mode with Jupiter

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  | No | - |

## Problem

Swap mode not supported 

## Solution

Added Swap mode in accordance with: https://station.jup.ag/docs/v6-beta/payments-api