### PR TITLE
:sparkles: Add maxSupportedTransactionVersion

### DIFF
--- a/src/Solana.Unity.Rpc/IRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IRpcClient.cs
@@ -546,7 +546,7 @@ namespace Solana.Unity.Rpc
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<ResponseValue<TokenBalance>>> GetTokenSupplyAsync(string tokenMintPubKey,
             Commitment commitment = default);
-        
+
         /// <summary>
         /// Returns transaction details for a confirmed transaction.
         /// <remarks>
@@ -558,9 +558,10 @@ namespace Solana.Unity.Rpc
         /// </summary>
         /// <param name="signature">Transaction signature as base-58 encoded string.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
+        /// <param name="maxSupportedTransactionVersion">The max supported transaction version (1 for versioned)</param>
         /// <returns>Returns a task that holds the asynchronous operation result and state.</returns>
         Task<RequestResult<TransactionMetaSlotInfo>> GetTransactionAsync(string signature,
-            Commitment commitment = default);
+            Commitment commitment = default, int maxSupportedTransactionVersion = 0);
 
         /// <summary>
         /// Returns transaction details for a confirmed transaction.

--- a/src/Solana.Unity.Rpc/SolanaRpcClient.cs
+++ b/src/Solana.Unity.Rpc/SolanaRpcClient.cs
@@ -433,11 +433,13 @@ namespace Solana.Unity.Rpc
 
         /// <inheritdoc cref="IRpcClient.GetTransactionAsync"/>
         public async Task<RequestResult<TransactionMetaSlotInfo>> GetTransactionAsync(string signature,
-            Commitment commitment = default)
+            Commitment commitment = default, int maxSupportedTransactionVersion = 0)
         {
             return await SendRequestAsync<TransactionMetaSlotInfo>("getTransaction",
                 Parameters.Create(signature,
-                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment))));
+                    ConfigObject.Create(KeyValue.Create("encoding", "json"), HandleCommitment(commitment),
+                    KeyValue.Create("maxSupportedTransactionVersion", maxSupportedTransactionVersion)))
+                );
         }
 
         /// <inheritdoc cref="IRpcClient.GetConfirmedTransactionAsync(string, Commitment)"/>

--- a/test/Solana.Unity.Rpc.Test/Resources/Http/Transaction/GetTransactionProcessedRequest.json
+++ b/test/Solana.Unity.Rpc.Test/Resources/Http/Transaction/GetTransactionProcessedRequest.json
@@ -1,1 +1,1 @@
-{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","commitment":"processed"}],"jsonrpc":"2.0","id":0}
+{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","commitment":"processed","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}

--- a/test/Solana.Unity.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest.json
+++ b/test/Solana.Unity.Rpc.Test/Resources/Http/Transaction/GetTransactionRequest.json
@@ -1,1 +1,1 @@
-{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json"}],"jsonrpc":"2.0","id":0}
+{"method":"getTransaction","params":["5as3w4KMpY23MP5T1nkPVksjXjN7hnjHKqiDxRMxUNcw5XsCGtStayZib1kQdyR2D9w8dR11Ha9Xk38KP3kbAwM1",{"encoding":"json","maxSupportedTransactionVersion":0}],"jsonrpc":"2.0","id":0}


### PR DESCRIPTION
Add maxSupportedTransactionVersion to GetTransactionAsync

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | https://github.com/magicblock-labs/Solana.Unity-SDK/issues/187 |

## Problem

See https://github.com/magicblock-labs/Solana.Unity-SDK/issues/187


## Solution

Added `maxSupportedTransactionVersion` parameter to `GetTransactionAsync`