### PR TITLE
 Fix and Improve Streaming Rpc

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Solana.Unity</Product>
-    <Version>2.6.1.2</Version>
+    <Version>2.6.1.3</Version>
     <Copyright>Copyright 2022 &#169; Magicblock Labs</Copyright>
     <Authors>Magicblock Labs</Authors>
     <PublisherName>Magicblock Labs</PublisherName>

--- a/src/Solana.Unity.Rpc/Core/Sockets/IWebSocket.cs
+++ b/src/Solana.Unity.Rpc/Core/Sockets/IWebSocket.cs
@@ -14,6 +14,9 @@ namespace Solana.Unity.Rpc.Core.Sockets
         Task CloseAsync(CancellationToken cancellationToken);
         Task SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken);
         Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken);
-        Task<WebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken);
+
+        public abstract event WebSocketMessageEventHandler OnMessage;
+        public delegate void WebSocketMessageEventHandler(byte[] data);
+        public event EventHandler<WebSocketState> ConnectionStateChangedEvent;
     }
 }

--- a/src/Solana.Unity.Rpc/Core/Sockets/SubscriptionState.cs
+++ b/src/Solana.Unity.Rpc/Core/Sockets/SubscriptionState.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Solana.Unity.Rpc.Messages;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,6 +30,11 @@ namespace Solana.Unity.Rpc.Core.Sockets
         /// The current state of the subscription.
         /// </summary>
         public SubscriptionStatus State { get; protected set; }
+        
+        /// <summary>
+        /// The JsonRpcRequest for this subscription.
+        /// </summary>
+        internal JsonRpcRequest Request;
 
         /// <summary>
         /// The last error message.
@@ -95,6 +101,15 @@ namespace Solana.Unity.Rpc.Core.Sockets
 
         /// <inheritdoc cref="Unsubscribe"/>
         public async Task UnsubscribeAsync() => await _rpcClient.UnsubscribeAsync(this).ConfigureAwait(false);
+
+        /// <summary>
+        /// Set the request for this subscription.
+        /// </summary>
+        /// <param name="request"></param>
+        public void SetRequest(JsonRpcRequest request)
+        {
+            Request = request;
+        }
     }
 
     /// <summary>

--- a/src/Solana.Unity.Rpc/Core/Sockets/WebSocketWrapper.cs
+++ b/src/Solana.Unity.Rpc/Core/Sockets/WebSocketWrapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,11 +12,9 @@ namespace Solana.Unity.Rpc.Core.Sockets
         private NativeWebSocket.IWebSocket webSocket;
 
         public WebSocketCloseStatus? CloseStatus => WebSocketCloseStatus.NormalClosure;
-
+        
         public string CloseStatusDescription => "Not implemented";
         
-        private readonly ConcurrentQueue<byte[]> _mMessageQueue = new();
-        private TaskCompletionSource<Tuple<byte[], WebSocketReceiveResult>> _receiveMessageTask;
         private TaskCompletionSource<bool> _webSocketConnectionTask = new();
 
         public WebSocketState State
@@ -63,21 +60,10 @@ namespace Solana.Unity.Rpc.Core.Sockets
         private void MessageReceived(byte[] message)
         {
             OnMessage?.Invoke(message);
-            _mMessageQueue.Enqueue(message);
-            DispatchMessage(message);
         }
 
         public Task CloseAsync(CancellationToken cancellationToken)
             => webSocket.Close();
-        
-        private void DispatchMessage(byte[] message)
-        {
-            if(_receiveMessageTask == null) return;
-            WebSocketReceiveResult webSocketReceiveResult = new(message.Length, WebSocketMessageType.Text, true);
-            Tuple<byte[], WebSocketReceiveResult> messageTuple = new(message, webSocketReceiveResult);
-            _receiveMessageTask.TrySetResult(messageTuple);
-            _receiveMessageTask = null;
-        }
 
         public event IWebSocket.WebSocketMessageEventHandler OnMessage;
         public event EventHandler<WebSocketState> ConnectionStateChangedEvent;

--- a/src/Solana.Unity.Rpc/IStreamingRpcClient.cs
+++ b/src/Solana.Unity.Rpc/IStreamingRpcClient.cs
@@ -1,8 +1,8 @@
+using System;
 using Solana.Unity.Rpc.Core.Sockets;
 using Solana.Unity.Rpc.Messages;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Rpc.Types;
-using System;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
 
@@ -32,6 +32,12 @@ namespace Solana.Unity.Rpc
         /// Statistics of the current connection.
         /// </summary>
         IConnectionStatistics Statistics { get; }
+        
+        /// <summary>
+        /// Set the default commitment used for requests.
+        /// </summary>
+        /// <param name="commitment"></param>
+        void SetDefaultCommitment(Commitment commitment);
 
         /// <summary>
         /// Subscribes asynchronously to AccountInfo notifications.
@@ -43,7 +49,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeAccountInfoAsync(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeAccountInfoAsync(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes to the AccountInfo. This is a synchronous and blocking function.
@@ -55,7 +61,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeAccountInfo(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeAccountInfo(string pubkey, Action<SubscriptionState, ResponseValue<AccountInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to Token Account notifications. Note: Only works if the account is a Token Account.
@@ -67,7 +73,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeTokenAccountAsync(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeTokenAccountAsync(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes  to Token Account notifications. Note: Only works if the account is a Token Account.
@@ -79,7 +85,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeTokenAccount(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeTokenAccount(string pubkey, Action<SubscriptionState, ResponseValue<TokenAccountInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to the logs notifications that mention a given public key.
@@ -91,7 +97,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeLogInfoAsync(string pubkey, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeLogInfoAsync(string pubkey, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to the logs notifications.
@@ -103,7 +109,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeLogInfoAsync(LogsSubscriptionType subscriptionType, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeLogInfoAsync(LogsSubscriptionType subscriptionType, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes to the logs notifications that mention a given public key. This is a synchronous and blocking function.
@@ -115,7 +121,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeLogInfo(string pubkey, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeLogInfo(string pubkey, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes to the logs notifications. This is a synchronous and blocking function.
@@ -127,7 +133,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeLogInfo(LogsSubscriptionType subscriptionType, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeLogInfo(LogsSubscriptionType subscriptionType, Action<SubscriptionState, ResponseValue<LogInfo>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to a transaction signature to receive notification when the transaction is confirmed.
@@ -139,7 +145,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeSignatureAsync(string transactionSignature, Action<SubscriptionState, ResponseValue<ErrorResult>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeSignatureAsync(string transactionSignature, Action<SubscriptionState, ResponseValue<ErrorResult>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes to a transaction signature to receive notification when the transaction is confirmed. This is a synchronous and blocking function.
@@ -151,7 +157,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeSignature(string transactionSignature, Action<SubscriptionState, ResponseValue<ErrorResult>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeSignature(string transactionSignature, Action<SubscriptionState, ResponseValue<ErrorResult>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to changes to a given program account data.
@@ -163,7 +169,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        Task<SubscriptionState> SubscribeProgramAsync(string programPubkey, Action<SubscriptionState, ResponseValue<AccountKeyPair>> callback, Commitment commitment = Commitment.Finalized);
+        Task<SubscriptionState> SubscribeProgramAsync(string programPubkey, Action<SubscriptionState, ResponseValue<AccountKeyPair>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes to changes to a given program account data. This is a synchronous and blocking function.
@@ -175,7 +181,7 @@ namespace Solana.Unity.Rpc
         /// <param name="callback">The callback to handle data notifications.</param>
         /// <param name="commitment">The state commitment to consider when querying the ledger state.</param>
         /// <returns>Returns an object representing the state of the subscription.</returns>
-        SubscriptionState SubscribeProgram(string programPubkey, Action<SubscriptionState, ResponseValue<AccountKeyPair>> callback, Commitment commitment = Commitment.Finalized);
+        SubscriptionState SubscribeProgram(string programPubkey, Action<SubscriptionState, ResponseValue<AccountKeyPair>> callback, Commitment commitment = default);
 
         /// <summary>
         /// Subscribes asynchronously to receive notifications anytime a slot is processed by the validator.

--- a/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
+++ b/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.*" />
     <PackageReference Include="IsExternalInit" Version="1.0.*" PrivateAssets="all" />
     <PackageReference Include="Unity3D.SDK" Version="2021.*" PrivateAssets="all" />
-    <PackageReference Include="native-websocket" Version="0.0.2" />
+    <PackageReference Include="native-websocket" Version="0.0.3" />
     <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Fix and Improve Streaming Rpc

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | https://github.com/magicblock-labs/Solana.Unity-SDK/issues/184, https://github.com/magicblock-labs/Solana.Unity-SDK/issues/182,  https://github.com/magicblock-labs/Solana.Unity-SDK/issues/183|

## Problem

- See https://github.com/magicblock-labs/Solana.Unity-SDK/issues/184, https://github.com/magicblock-labs/Solana.Unity-SDK/issues/182,  https://github.com/magicblock-labs/Solana.Unity-SDK/issues/183 for detailed descriptions

## Solution

- Default values for localhost
- WebSockets now try to reconnect when losing connection
- Global settable default Commitment for IStreamingRpc
- Several fixes in the Websockets, removed the need for a dispatcher object and replaced infinite loop with events