### PR TITLE
:arrow_up: Upgrade TargetFramework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           dotnet tool install Cake.Tool --version 1.1.0
           dotnet tool restore
-          sh -c "$(curl -sSfL https://release.solana.com/v1.14.11/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           solana-test-validator -u m -c whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc -c CtXfPzz36dH5Ws4UYKZvrQ1Xqzn42ecDW6y8NKuiN8nD -c metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s -c PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT --mint 5ZWj7a1f8tWkjBESHKgrLmXshuXxqeY9SYcfbshpAqPG > /dev/null &
           sleep 5

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Check out Code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Get the sources
         uses: actions/checkout@v2
       - name: Extract release notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           dotnet tool install Cake.Tool --version 1.1.0
           dotnet tool restore
-          sh -c "$(curl -sSfL https://release.solana.com/v1.14.11/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           solana-test-validator -u m -c whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc -c CtXfPzz36dH5Ws4UYKZvrQ1Xqzn42ecDW6y8NKuiN8nD -c metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s -c PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT --mint 5ZWj7a1f8tWkjBESHKgrLmXshuXxqeY9SYcfbshpAqPG > /dev/null &
           sleep 5

--- a/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
+++ b/src/Solana.Unity.Dex/Solana.Unity.Dex.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <PackageId>Solana.Unity.Dex</PackageId>
     </PropertyGroup>
 

--- a/src/Solana.Unity.Examples/Solana.Unity.Examples.csproj
+++ b/src/Solana.Unity.Examples/Solana.Unity.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Solana.Unity.Extensions/Solana.Unity.Extensions.csproj
+++ b/src/Solana.Unity.Extensions/Solana.Unity.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
+++ b/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Solana.Unity.Programs/Solana.Unity.Programs.csproj
+++ b/src/Solana.Unity.Programs/Solana.Unity.Programs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
+++ b/src/Solana.Unity.Rpc/Solana.Unity.Rpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Solana.Unity.Rpc</PackageId>
   </PropertyGroup>
 

--- a/src/Solana.Unity.Wallet/Solana.Unity.Wallet.csproj
+++ b/src/Solana.Unity.Wallet/Solana.Unity.Wallet.csproj
@@ -4,7 +4,7 @@
     <Description>
       Solana.Unity.Wallet uses BIP32 and BIP39 to generate an HD tree of Solana compatible addresses from a randomly generated word seed.
     </Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Solana.Unity.Dex.Test/Solana.Unity.Dex.Test.csproj
+++ b/test/Solana.Unity.Dex.Test/Solana.Unity.Dex.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/Solana.Unity.Extensions.Test/Solana.Unity.Extensions.Test.csproj
+++ b/test/Solana.Unity.Extensions.Test/Solana.Unity.Extensions.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Solana.Unity.KeyStore.Test/Solana.Unity.KeyStore.Test.csproj
+++ b/test/Solana.Unity.KeyStore.Test/Solana.Unity.KeyStore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/Solana.Unity.Programs.Test/Solana.Unity.Programs.Test.csproj
+++ b/test/Solana.Unity.Programs.Test/Solana.Unity.Programs.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Solana.Unity.Rpc.Test/Solana.Unity.Rpc.Test.csproj
+++ b/test/Solana.Unity.Rpc.Test/Solana.Unity.Rpc.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Solana.Unity.Wallet.Test/Solana.Unity.Wallet.Test.csproj
+++ b/test/Solana.Unity.Wallet.Test/Solana.Unity.Wallet.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
# Incompatibilities with Unity 2023.2.10f1 when building dlls for Android

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | - |

## Problem

See https://github.com/magicblock-labs/Solana.Unity-SDK/issues/237

## Solution

- [x] Compile with .net 8.0 SDK
- [x] Update TargetFramework from netstandard2.0 to netstandard2.1
- [ ] Update Unity bindings, (candidate replacement for Unity3D.SDK) is https://github.com/Rabadash8820/UnityAssemblies/tree/main 