### PR TITLE
Updated GetRecentBlockHash to GetLatestBlockHash

### DIFF
--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
@@ -22,6 +22,7 @@ using Solana.Unity.Dex.Orca.Orca;
 using Solana.Unity.Dex.Quotes;
 using Solana.Unity.Dex.Ticks;
 using System.Linq;
+using Solana.Unity.Rpc.Core.Http;
 
 namespace Orca
 {
@@ -1069,7 +1070,8 @@ namespace Orca
         )
         {
             tb.SetFeePayer(feePayer);
-            tb.SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHash = await rpcClient.GetLatestBlockHashAsync();
+            tb.SetRecentBlockHash(latestBlockHash.Result.Value.Blockhash);
 
             return Transaction.Deserialize(tb.Serialize());
         }

--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
@@ -1070,7 +1070,7 @@ namespace Orca
         )
         {
             tb.SetFeePayer(feePayer);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHash = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHash = await rpcClient.GetLatestBlockHashAsync();
             tb.SetRecentBlockHash(latestBlockHash.Result.Value.Blockhash);
 
             return Transaction.Deserialize(tb.Serialize());

--- a/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
+++ b/src/Solana.Unity.Dex/Orca/Orca/OrcaDex.cs
@@ -1069,7 +1069,7 @@ namespace Orca
         )
         {
             tb.SetFeePayer(feePayer);
-            tb.SetRecentBlockHash((await rpcClient.GetRecentBlockHashAsync(commitment)).Result.Value.Blockhash);
+            tb.SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
 
             return Transaction.Deserialize(tb.Serialize());
         }

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
@@ -56,7 +56,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             var tb = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(from.PublicKey)
@@ -84,7 +84,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             var tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer)

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
@@ -55,10 +55,8 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
-            var recentHash = await ctx.RpcClient.GetRecentBlockHashAsync();
-
             var tb = new TransactionBuilder()
-                .SetRecentBlockHash(recentHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(from.PublicKey)
                 .AddInstruction(SystemProgram.Transfer(from.PublicKey, to, lamports));
 
@@ -84,10 +82,8 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
-            var recentHash = await ctx.RpcClient.GetRecentBlockHashAsync();
-
             var tx = new TransactionBuilder()
-                .SetRecentBlockHash(recentHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(feePayer)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: fromAccount,

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/SystemUtils.cs
@@ -7,6 +7,7 @@ using Solana.Unity.Rpc.Builders;
 using Solana.Unity.Rpc.Types;
 using Solana.Unity.Rpc.Core.Http;
 using Solana.Unity.Programs;
+using Solana.Unity.Rpc.Models;
 
 namespace Solana.Unity.Dex.Orca.SolanaApi
 {
@@ -55,8 +56,9 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             var tb = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(from.PublicKey)
                 .AddInstruction(SystemProgram.Transfer(from.PublicKey, to, lamports));
 
@@ -82,8 +84,9 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Commitment commitment = Commitment.Finalized
         )
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             var tx = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: fromAccount,

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
@@ -35,7 +35,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             ulong minBalanceForExemptionMint =
                 (await rpc.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
@@ -82,7 +82,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
                 
                 var tempAccount = new Account();
                 var sta = AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(tempAccount, mint);
-                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+                var latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 var trxBuild=  new TransactionBuilder()    
                     .SetFeePayer(feePayer.PublicKey)
                     .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
@@ -124,7 +124,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             }
             else
             {
-                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+                var latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 var txBuilder = new TransactionBuilder()
                     .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                     .SetFeePayer(feePayer.PublicKey)
@@ -168,7 +168,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Account feePayer
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
@@ -34,8 +34,7 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             ulong minBalanceForExemptionMint =
                 (await rpc.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             
-            var blockHash = await rpc.GetRecentBlockHashAsync();
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: authority,
@@ -79,12 +78,11 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
                 ulong rentExemptionMin =
                     (await rpc.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
                 
-                var blockHash = await rpc.GetRecentBlockHashAsync();
                 var tempAccount = new Account();
                 var sta = AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(tempAccount, mint);
                 var trxBuild=  new TransactionBuilder()    
                     .SetFeePayer(feePayer.PublicKey)
-                    .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                    .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                     .AddInstruction(SystemProgram.CreateAccount(
                         feePayer,
                         tempAccount,
@@ -123,9 +121,8 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             }
             else
             {
-                var blockHash = await rpc.GetRecentBlockHashAsync();
                 var txBuilder = new TransactionBuilder()
-                    .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                    .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                     .SetFeePayer(feePayer.PublicKey)
                     .AddInstruction(
                         AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
@@ -167,9 +164,8 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Account feePayer
         )
         {
-            var blockHash = await rpc.GetRecentBlockHashAsync();
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)
                 .AddInstruction(TokenProgram.MintTo(
                     mint,

--- a/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
+++ b/src/Solana.Unity.Dex/Orca/SolanaApi/TokenUtilsTransaction.cs
@@ -10,6 +10,7 @@ using Solana.Unity.Dex.Orca.Address;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Rpc.Types;
+using Solana.Unity.Rpc.Core.Http;
 
 namespace Solana.Unity.Dex.Orca.SolanaApi
 {
@@ -33,8 +34,9 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
         {
             ulong minBalanceForExemptionMint =
                 (await rpc.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
-            
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: authority,
@@ -80,9 +82,10 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
                 
                 var tempAccount = new Account();
                 var sta = AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(tempAccount, mint);
+                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 var trxBuild=  new TransactionBuilder()    
                     .SetFeePayer(feePayer.PublicKey)
-                    .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                    .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                     .AddInstruction(SystemProgram.CreateAccount(
                         feePayer,
                         tempAccount,
@@ -121,8 +124,9 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             }
             else
             {
+                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 var txBuilder = new TransactionBuilder()
-                    .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                    .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                     .SetFeePayer(feePayer.PublicKey)
                     .AddInstruction(
                         AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
@@ -164,8 +168,9 @@ namespace Solana.Unity.Dex.Orca.SolanaApi
             Account feePayer
         )
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)
                 .AddInstruction(TokenProgram.MintTo(
                     mint,

--- a/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
@@ -48,7 +48,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"MintAccount: {mintAccount}");
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             byte[] createAndInitializeMintToTx = new TransactionBuilder().

--- a/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
@@ -48,7 +48,8 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"MintAccount: {mintAccount}");
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            string latestBlockHash = RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             byte[] createAndInitializeMintToTx = new TransactionBuilder().
                 SetRecentBlockHash(latestBlockHash).

--- a/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
+++ b/src/Solana.Unity.Examples/AssociatedTokenAccountsExample.cs
@@ -33,8 +33,6 @@ namespace Solana.Unity.Examples
             #region Create and Initialize a token Mint Account
 
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionAcc =
                 (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             ulong minBalanceForExemptionMint =
@@ -50,8 +48,10 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"MintAccount: {mintAccount}");
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
+            string latestBlockHash = RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+
             byte[] createAndInitializeMintToTx = new TransactionBuilder().
-                SetRecentBlockHash(blockHash.Result.Value.Blockhash).
+                SetRecentBlockHash(latestBlockHash).
                 SetFeePayer(ownerAccount).
                 AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -104,7 +104,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"AssociatedTokenAccount: {associatedTokenAccount}");
 
             byte[] createAssociatedTokenAccountTx = new TransactionBuilder().
-                SetRecentBlockHash(blockHash.Result.Value.Blockhash).
+                SetRecentBlockHash(latestBlockHash).
                 SetFeePayer(ownerAccount).
                 AddInstruction(AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
                     ownerAccount,

--- a/src/Solana.Unity.Examples/HelloWorldExample.cs
+++ b/src/Solana.Unity.Examples/HelloWorldExample.cs
@@ -1,6 +1,8 @@
 ﻿using Solana.Unity.Programs;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Builders;
+using Solana.Unity.Rpc.Core.Http;
+using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using Solana.Unity.Wallet.Bip39;
 using System;
@@ -43,8 +45,10 @@ namespace Solana.Unity.Examples
 
                     var memoInstruction = MemoProgram.NewMemoV2("Hello Solana World, using Solana.Unity :)");
 
+                    RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
                     var tx = new TransactionBuilder().AddInstruction(memoInstruction).SetFeePayer(wallet.Account)
-                        .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash).Build(wallet.Account);
+                        .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash).Build(wallet.Account);
 
                     var txHash = await rpcClient.SendTransactionAsync(tx);
 

--- a/src/Solana.Unity.Examples/HelloWorldExample.cs
+++ b/src/Solana.Unity.Examples/HelloWorldExample.cs
@@ -45,7 +45,7 @@ namespace Solana.Unity.Examples
 
                     var memoInstruction = MemoProgram.NewMemoV2("Hello Solana World, using Solana.Unity :)");
 
-                    RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+                    var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
                     var tx = new TransactionBuilder().AddInstruction(memoInstruction).SetFeePayer(wallet.Account)
                         .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash).Build(wallet.Account);

--- a/src/Solana.Unity.Examples/HelloWorldExample.cs
+++ b/src/Solana.Unity.Examples/HelloWorldExample.cs
@@ -43,10 +43,8 @@ namespace Solana.Unity.Examples
 
                     var memoInstruction = MemoProgram.NewMemoV2("Hello Solana World, using Solana.Unity :)");
 
-                    var recentHash = await rpcClient.GetRecentBlockHashAsync();
-
                     var tx = new TransactionBuilder().AddInstruction(memoInstruction).SetFeePayer(wallet.Account)
-                        .SetRecentBlockHash(recentHash.Result.Value.Blockhash).Build(wallet.Account);
+                        .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash).Build(wallet.Account);
 
                     var txHash = await rpcClient.SendTransactionAsync(tx);
 

--- a/src/Solana.Unity.Examples/InstructionDecoderExample.cs
+++ b/src/Solana.Unity.Examples/InstructionDecoderExample.cs
@@ -25,7 +25,7 @@ namespace Solana.Unity.Examples
             var fromAccount = wallet.GetAccount(10);
             var toAccount = wallet.GetAccount(8);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 

--- a/src/Solana.Unity.Examples/InstructionDecoderExample.cs
+++ b/src/Solana.Unity.Examples/InstructionDecoderExample.cs
@@ -1,6 +1,7 @@
 ﻿using Solana.Unity.Programs;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Builders;
+using Solana.Unity.Rpc.Core.Http;
 using Solana.Unity.Rpc.Models;
 using System;
 using System.IO;
@@ -24,7 +25,8 @@ namespace Solana.Unity.Examples
             var fromAccount = wallet.GetAccount(10);
             var toAccount = wallet.GetAccount(8);
 
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             var msgBytes = new TransactionBuilder()

--- a/src/Solana.Unity.Examples/InstructionDecoderExample.cs
+++ b/src/Solana.Unity.Examples/InstructionDecoderExample.cs
@@ -24,11 +24,11 @@ namespace Solana.Unity.Examples
             var fromAccount = wallet.GetAccount(10);
             var toAccount = wallet.GetAccount(8);
 
-            var blockHash = await rpcClient.GetRecentBlockHashAsync();
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             var msgBytes = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.Transfer(fromAccount.PublicKey, toAccount.PublicKey, 10000000))
                 .AddInstruction(MemoProgram.NewMemo(fromAccount.PublicKey, "Hello from Sol.Net :)"))

--- a/src/Solana.Unity.Examples/MultisigExamples.cs
+++ b/src/Solana.Unity.Examples/MultisigExamples.cs
@@ -27,8 +27,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -51,7 +49,7 @@ namespace Solana.Unity.Examples
             Account signerAccount4 = wallet.GetAccount(25103);
             Account signerAccount5 = wallet.GetAccount(25104);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -92,9 +90,7 @@ namespace Solana.Unity.Examples
             string createMultiSigAndMintSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(createMultiSigAndMintSignature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -155,8 +151,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -177,7 +171,7 @@ namespace Solana.Unity.Examples
             Account signerAccount2 = wallet.GetAccount(25101);
             Account signerAccount4 = wallet.GetAccount(25103);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
                     mintAccount.PublicKey,
@@ -228,7 +222,7 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
 
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
@@ -257,7 +251,7 @@ namespace Solana.Unity.Examples
             // First we create a multi sig account to use as the token account authority
             // In this same transaction we transfer tokens using TransferChecked from the initialAccount in the example above
             // to the same token account we just finished creating
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -312,7 +306,7 @@ namespace Solana.Unity.Examples
 
             // After the previous transaction is confirmed we use TransferChecked to transfer tokens using the
             // multi sig account back to the initial account
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Transfer(
                     tokenAccountWithMultisigOwner,
@@ -360,8 +354,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -393,7 +385,7 @@ namespace Solana.Unity.Examples
             Account freezeSigner5 = wallet.GetAccount(25414);
 
             // First we create a multi sig account to use as the token's freeze authority
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -428,12 +420,9 @@ namespace Solana.Unity.Examples
             string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
-
             // Then we create an account which will be the token's mint authority
             // In this same transaction we initialize the token mint with said authorities
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -480,10 +469,8 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             // Here we mint tokens to an account using the mint authority multi sig
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -527,11 +514,9 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             // After doing this, we freeze the account to which we just minted tokens
             // Notice how the signers used are different, because the `freezeAuthority` has different signers
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.FreezeAccount(
                         initialAccount,
@@ -564,10 +549,8 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             // Because we're actually cool people, we now thaw that same account and then set the authority to nothing
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.ThawAccount(
                     initialAccount,
@@ -628,8 +611,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -667,7 +648,7 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -704,9 +685,7 @@ namespace Solana.Unity.Examples
             string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -750,9 +729,7 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.ApproveChecked(
                         tokenAccountWithMultisigOwner,
@@ -787,10 +764,7 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            blockHash = await rpcClient.GetRecentBlockHashAsync();
-
-
-            msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.TransferChecked(
                     tokenAccountWithMultisigOwner,
@@ -846,8 +820,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -880,7 +852,7 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
                     mintAccount,
@@ -947,8 +919,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -975,7 +945,7 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Account Balance >> {balance.Result.Value.UiAmountString}");
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.BurnChecked(
                     mintAccount,

--- a/src/Solana.Unity.Examples/MultisigExamples.cs
+++ b/src/Solana.Unity.Examples/MultisigExamples.cs
@@ -49,7 +49,7 @@ namespace Solana.Unity.Examples
             Account signerAccount4 = wallet.GetAccount(25103);
             Account signerAccount5 = wallet.GetAccount(25104);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
@@ -173,7 +173,7 @@ namespace Solana.Unity.Examples
             Account signerAccount2 = wallet.GetAccount(25101);
             Account signerAccount4 = wallet.GetAccount(25103);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
@@ -225,7 +225,7 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             ulong minBalanceForExemptionMultiSig =
@@ -389,7 +389,7 @@ namespace Solana.Unity.Examples
             Account freezeSigner5 = wallet.GetAccount(25414);
 
             // First we create a multi sig account to use as the token's freeze authority
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
@@ -657,7 +657,7 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
@@ -865,7 +865,7 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
@@ -959,7 +959,7 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Account Balance >> {balance.Result.Value.UiAmountString}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.BurnChecked(

--- a/src/Solana.Unity.Examples/MultisigExamples.cs
+++ b/src/Solana.Unity.Examples/MultisigExamples.cs
@@ -49,7 +49,8 @@ namespace Solana.Unity.Examples
             Account signerAccount4 = wallet.GetAccount(25103);
             Account signerAccount5 = wallet.GetAccount(25104);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -90,7 +91,8 @@ namespace Solana.Unity.Examples
             string createMultiSigAndMintSignature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(createMultiSigAndMintSignature);
 
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -171,7 +173,8 @@ namespace Solana.Unity.Examples
             Account signerAccount2 = wallet.GetAccount(25101);
             Account signerAccount4 = wallet.GetAccount(25103);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
                     mintAccount.PublicKey,
@@ -222,7 +225,8 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
@@ -385,7 +389,8 @@ namespace Solana.Unity.Examples
             Account freezeSigner5 = wallet.GetAccount(25414);
 
             // First we create a multi sig account to use as the token's freeze authority
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -422,7 +427,8 @@ namespace Solana.Unity.Examples
 
             // Then we create an account which will be the token's mint authority
             // In this same transaction we initialize the token mint with said authorities
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -470,7 +476,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(signature);
 
             // Here we mint tokens to an account using the mint authority multi sig
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount,
@@ -516,7 +523,8 @@ namespace Solana.Unity.Examples
 
             // After doing this, we freeze the account to which we just minted tokens
             // Notice how the signers used are different, because the `freezeAuthority` has different signers
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.FreezeAccount(
                         initialAccount,
@@ -550,7 +558,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(signature);
 
             // Because we're actually cool people, we now thaw that same account and then set the authority to nothing
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.ThawAccount(
                     initialAccount,
@@ -648,7 +657,8 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -685,7 +695,8 @@ namespace Solana.Unity.Examples
             string signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -729,7 +740,8 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.ApproveChecked(
                         tokenAccountWithMultisigOwner,
@@ -764,7 +776,8 @@ namespace Solana.Unity.Examples
             signature = await Examples.SubmitTxSendAndLog(txBytes);
             Examples.PollConfirmedTx(signature);
 
-            msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.TransferChecked(
                     tokenAccountWithMultisigOwner,
@@ -852,7 +865,8 @@ namespace Solana.Unity.Examples
             Account tokenAccountSigner4 = wallet.GetAccount(25493);
             Account tokenAccountSigner5 = wallet.GetAccount(25494);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintToChecked(
                     mintAccount,
@@ -945,7 +959,8 @@ namespace Solana.Unity.Examples
 
             Console.WriteLine($"Account Balance >> {balance.Result.Value.UiAmountString}");
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.BurnChecked(
                     mintAccount,

--- a/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
+++ b/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
@@ -53,7 +53,6 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(MnemonicWords);
 
-            var blockHash = await rpcClient.GetRecentBlockHashAsync();
             var minBalanceForExemptionNameAcc =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(NameServiceProgram.NameAccountSize + 96)).Result;
 
@@ -76,7 +75,7 @@ namespace Solana.Unity.Examples
             var reverseRegistry = GetReverseRegistryKey(ownerAccount.PublicKey.Key);
             Console.WriteLine($"ReverseRegistryKey: {reverseRegistry.Key}");
 
-            var tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            var tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(payerAccount).AddInstruction(
                     NameServiceProgram.CreateNameRegistry(
                         twitterHandleRegistry,

--- a/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
+++ b/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
@@ -1,6 +1,8 @@
 using Solana.Unity.Programs;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Builders;
+using Solana.Unity.Rpc.Core.Http;
+using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using System;
 using System.Threading.Tasks;
@@ -75,7 +77,8 @@ namespace Solana.Unity.Examples
             var reverseRegistry = GetReverseRegistryKey(ownerAccount.PublicKey.Key);
             Console.WriteLine($"ReverseRegistryKey: {reverseRegistry.Key}");
 
-            var tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(payerAccount).AddInstruction(
                     NameServiceProgram.CreateNameRegistry(
                         twitterHandleRegistry,

--- a/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
+++ b/src/Solana.Unity.Examples/NameServiceProgramExamples.cs
@@ -77,7 +77,7 @@ namespace Solana.Unity.Examples
             var reverseRegistry = GetReverseRegistryKey(ownerAccount.PublicKey.Key);
             Console.WriteLine($"ReverseRegistryKey: {reverseRegistry.Key}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             var tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(payerAccount).AddInstruction(
                     NameServiceProgram.CreateNameRegistry(

--- a/src/Solana.Unity.Examples/StakeExample.cs
+++ b/src/Solana.Unity.Examples/StakeExample.cs
@@ -24,7 +24,8 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             await rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "yrdy1", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
@@ -64,7 +65,8 @@ namespace Solana.Unity.Examples
             var b58 = new Base58Encoder();
             string f = b58.EncodeData(seed);
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
@@ -105,7 +107,8 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
@@ -142,7 +145,8 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog5", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
@@ -197,7 +201,8 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account stakeAccount = wallet.GetAccount(22);
@@ -250,7 +255,8 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
 
             Account a6 = wallet.GetAccount(6);

--- a/src/Solana.Unity.Examples/StakeExample.cs
+++ b/src/Solana.Unity.Examples/StakeExample.cs
@@ -24,14 +24,14 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             await rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "yrdy1", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.CreateAccountWithSeed(
                      fromAccount,
@@ -64,17 +64,17 @@ namespace Solana.Unity.Examples
             var b58 = new Base58Encoder();
             string f = b58.EncodeData(seed);
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
             rpcClient.RequestAirdropAsync(toAccount.PublicKey, 100_000_000);
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog5", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
 
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(StakeProgram.AuthorizeWithSeed(
                     stakeAccount,
@@ -105,16 +105,16 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
 
             Account fromAccount = wallet.Account;
             Account toAccount = wallet.GetAccount(1);
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog1", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
 
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(StakeProgram.Authorize(
                     stakeAccount,
@@ -142,7 +142,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             PublicKey.TryCreateWithSeed(fromAccount.PublicKey, "dog5", StakeProgram.ProgramIdKey, out PublicKey stakeAccount);
@@ -158,10 +158,10 @@ namespace Solana.Unity.Examples
                 UnixTimestamp = 0
             };
 
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.CreateAccountWithSeed(
                     fromAccount.PublicKey,
@@ -197,7 +197,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
             Account stakeAccount = wallet.GetAccount(22);
@@ -214,10 +214,10 @@ namespace Solana.Unity.Examples
                 UnixTimestamp = 0
             };
 
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount.PublicKey,
@@ -250,7 +250,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
 
             Account a6 = wallet.GetAccount(6);
@@ -258,10 +258,10 @@ namespace Solana.Unity.Examples
             Account a4 = wallet.GetAccount(4);
             Account a3 = wallet.GetAccount(3);
 
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(a6)
                 .AddInstruction(SystemProgram.CreateAccountWithSeed(
                     a6.PublicKey,

--- a/src/Solana.Unity.Examples/StakeExample.cs
+++ b/src/Solana.Unity.Examples/StakeExample.cs
@@ -24,7 +24,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             await rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
@@ -65,7 +65,7 @@ namespace Solana.Unity.Examples
             var b58 = new Base58Encoder();
             string f = b58.EncodeData(seed);
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
@@ -107,7 +107,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
 
             Account fromAccount = wallet.Account;
@@ -145,7 +145,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
@@ -201,7 +201,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minbalanceforexception = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
             Account fromAccount = wallet.Account;
@@ -255,7 +255,7 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(new Mnemonic(MnemonicWords));
             rpcClient.RequestAirdropAsync(wallet.Account.PublicKey, 100_000_000);
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             ulong minBalance = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(StakeProgram.StakeAccountDataSize)).Result;
 

--- a/src/Solana.Unity.Examples/TokenSwapExample.cs
+++ b/src/Solana.Unity.Examples/TokenSwapExample.cs
@@ -35,7 +35,7 @@ namespace Solana.Unity.Examples
             var tokenBMint = new Account();
             var tokenBUserAccount = new Account();
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
 
             //setup some mints and tokens owned by wallet
             var tx = new TransactionBuilder()

--- a/src/Solana.Unity.Examples/TokenSwapExample.cs
+++ b/src/Solana.Unity.Examples/TokenSwapExample.cs
@@ -36,9 +36,8 @@ namespace Solana.Unity.Examples
             var tokenBUserAccount = new Account();
 
             //setup some mints and tokens owned by wallet
-            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
             var tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -112,9 +111,8 @@ namespace Solana.Unity.Examples
             var swapTokenBAccount = new Account();
 
             //init the swap authority's token accounts
-            blockHash = await RpcClient.GetRecentBlockHashAsync();
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -161,9 +159,8 @@ namespace Solana.Unity.Examples
             var poolFeeAccount = new Account();
 
             //create the pool mint and the user and fee pool token accounts
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -206,9 +203,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //create the swap
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -247,9 +243,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //now a user can swap in the pool
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.Swap(
                     swap,
@@ -268,9 +263,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //user can add liq
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.DepositAllTokenTypes(
                     swap,
@@ -289,9 +283,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //user can remove liq
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.WithdrawAllTokenTypes(
                     swap,
@@ -311,9 +304,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //user can deposit single
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.DepositSingleTokenTypeExactAmountIn(
                     swap,
@@ -330,9 +322,8 @@ namespace Solana.Unity.Examples
             Examples.PollConfirmedTx(txSig);
 
             //user can withdraw single
-            blockHash = await RpcClient.GetRecentBlockHashAsync();;
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.WithdrawSingleTokenTypeExactAmountOut(
                     swap,

--- a/src/Solana.Unity.Examples/TokenSwapExample.cs
+++ b/src/Solana.Unity.Examples/TokenSwapExample.cs
@@ -35,9 +35,11 @@ namespace Solana.Unity.Examples
             var tokenBMint = new Account();
             var tokenBUserAccount = new Account();
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //setup some mints and tokens owned by wallet
             var tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -110,9 +112,11 @@ namespace Solana.Unity.Examples
             var swapTokenAAccount= new Account();
             var swapTokenBAccount = new Account();
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //init the swap authority's token accounts
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -158,9 +162,11 @@ namespace Solana.Unity.Examples
             var poolUserAccount = new Account();
             var poolFeeAccount = new Account();
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //create the pool mint and the user and fee pool token accounts
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -202,9 +208,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //create the swap
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(SystemProgram.CreateAccount(
                     wallet.Account,
@@ -242,9 +250,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //now a user can swap in the pool
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.Swap(
                     swap,
@@ -262,9 +272,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //user can add liq
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.DepositAllTokenTypes(
                     swap,
@@ -282,9 +294,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //user can remove liq
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.WithdrawAllTokenTypes(
                     swap,
@@ -303,9 +317,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //user can deposit single
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.DepositSingleTokenTypeExactAmountIn(
                     swap,
@@ -321,9 +337,11 @@ namespace Solana.Unity.Examples
             txSig = await Examples.SubmitTxSendAndLog(tx);
             Examples.PollConfirmedTx(txSig);
 
+            latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             //user can withdraw single
             tx = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(wallet.Account)
                 .AddInstruction(program.WithdrawSingleTokenTypeExactAmountOut(
                     swap,

--- a/src/Solana.Unity.Examples/TransactionBuilderExample.cs
+++ b/src/Solana.Unity.Examples/TransactionBuilderExample.cs
@@ -27,7 +27,7 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
@@ -74,7 +74,7 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(3333);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -145,7 +145,7 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(26);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -192,7 +192,7 @@ namespace Solana.Unity.Examples
             Account newAccount = wallet.GetAccount(33);
             Console.WriteLine($"NewAccount: {newAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -250,7 +250,7 @@ namespace Solana.Unity.Examples
             Account newAccount = wallet.GetAccount(27);
             Console.WriteLine($"NewAccount: {newAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
@@ -309,7 +309,7 @@ namespace Solana.Unity.Examples
             Account newAuthority = wallet.GetAccount(1129);
             Console.WriteLine($"NewAuthority: {newAuthority}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
@@ -419,7 +419,7 @@ namespace Solana.Unity.Examples
             Account mintAccount = wallet.GetAccount(21);
             Account initialAccount = wallet.GetAccount(26);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
 
             byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -459,7 +459,7 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 

--- a/src/Solana.Unity.Examples/TransactionBuilderExample.cs
+++ b/src/Solana.Unity.Examples/TransactionBuilderExample.cs
@@ -27,11 +27,11 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.Transfer(fromAccount.PublicKey, toAccount.PublicKey, 10000000))
                 .AddInstruction(MemoProgram.NewMemo(fromAccount.PublicKey, "Hello from Sol.Net :)"))
@@ -58,7 +58,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
@@ -74,7 +73,7 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(3333);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -128,7 +127,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
@@ -144,7 +142,7 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(26);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintTo(
                     mintAccount.PublicKey,
@@ -177,7 +175,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc = (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
 
@@ -190,7 +187,7 @@ namespace Solana.Unity.Examples
             Account newAccount = wallet.GetAccount(33);
             Console.WriteLine($"NewAccount: {newAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -233,7 +230,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption Account >> {minBalanceForExemptionAcc}");
@@ -248,7 +244,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"NewAccount: {newAccount}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                         ownerAccount.PublicKey,
@@ -294,7 +290,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(NonceAccount.AccountDataSize)).Result;
 
@@ -306,7 +301,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"NewAuthority: {newAuthority}");
 
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -399,8 +394,6 @@ namespace Solana.Unity.Examples
         {
             Wallet.Wallet wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-
             ulong minBalanceForExemptionMultiSig =
                 (await rpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MultisigAccountDataSize)).Result;
             Console.WriteLine($"MinBalanceForRentExemption MultiSig >> {minBalanceForExemptionMultiSig}");
@@ -415,7 +408,7 @@ namespace Solana.Unity.Examples
             Account mintAccount = wallet.GetAccount(21);
             Account initialAccount = wallet.GetAccount(26);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Burn(
                     initialAccount.PublicKey,
@@ -453,11 +446,11 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await rpcClient.GetRecentBlockHashAsync();
-            Console.WriteLine($"BlockHash >> {blockHash.Result.Value.Blockhash}");
+            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             TransactionBuilder txBuilder = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.Transfer(fromAccount.PublicKey, toAccount.PublicKey, 10000000))
                 .AddInstruction(MemoProgram.NewMemo(fromAccount.PublicKey, "Hello from Sol.Net :)"));

--- a/src/Solana.Unity.Examples/TransactionBuilderExample.cs
+++ b/src/Solana.Unity.Examples/TransactionBuilderExample.cs
@@ -27,7 +27,8 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             byte[] tx = new TransactionBuilder()
@@ -73,7 +74,9 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(3333);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -142,7 +145,9 @@ namespace Solana.Unity.Examples
             Account initialAccount = wallet.GetAccount(26);
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.MintTo(
                     mintAccount.PublicKey,
@@ -187,7 +192,9 @@ namespace Solana.Unity.Examples
             Account newAccount = wallet.GetAccount(33);
             Console.WriteLine($"NewAccount: {newAccount}");
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -243,8 +250,10 @@ namespace Solana.Unity.Examples
             Account newAccount = wallet.GetAccount(27);
             Console.WriteLine($"NewAccount: {newAccount}");
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                         ownerAccount.PublicKey,
@@ -300,8 +309,10 @@ namespace Solana.Unity.Examples
             Account newAuthority = wallet.GetAccount(1129);
             Console.WriteLine($"NewAuthority: {newAuthority}");
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     ownerAccount.PublicKey,
@@ -408,7 +419,9 @@ namespace Solana.Unity.Examples
             Account mintAccount = wallet.GetAccount(21);
             Account initialAccount = wallet.GetAccount(26);
 
-            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+
+            byte[] msgData = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Burn(
                     initialAccount.PublicKey,
@@ -446,7 +459,8 @@ namespace Solana.Unity.Examples
             Account fromAccount = wallet.GetAccount(10);
             Account toAccount = wallet.GetAccount(8);
 
-            string latestBlockHash = rpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpcClient.GetLatestBlockHashAsync();
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             Console.WriteLine($"BlockHash >> {latestBlockHash}");
 
             TransactionBuilder txBuilder = new TransactionBuilder()

--- a/src/Solana.Unity.Examples/TransactionDecodingExample.cs
+++ b/src/Solana.Unity.Examples/TransactionDecodingExample.cs
@@ -42,7 +42,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"MintAccount: {mintAccount}");
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
 
             byte[] msgData = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)

--- a/src/Solana.Unity.Examples/TransactionDecodingExample.cs
+++ b/src/Solana.Unity.Examples/TransactionDecodingExample.cs
@@ -27,7 +27,6 @@ namespace Solana.Unity.Examples
         {
             var wallet = new Wallet.Wallet(MnemonicWords);
 
-            RequestResult<ResponseValue<BlockHash>> blockHash = await RpcClient.GetRecentBlockHashAsync();
             ulong minBalanceForExemptionAcc =
                 (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
             ulong minBalanceForExemptionMint =
@@ -44,7 +43,7 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
             byte[] msgData = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.InitializeMint(
                     mintAccount.PublicKey,

--- a/src/Solana.Unity.Examples/TransactionDecodingExample.cs
+++ b/src/Solana.Unity.Examples/TransactionDecodingExample.cs
@@ -42,8 +42,10 @@ namespace Solana.Unity.Examples
             Console.WriteLine($"MintAccount: {mintAccount}");
             Console.WriteLine($"InitialAccount: {initialAccount}");
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+
             byte[] msgData = new TransactionBuilder()
-                .SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.InitializeMint(
                     mintAccount.PublicKey,

--- a/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
+++ b/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
@@ -54,7 +54,7 @@ namespace Solana.Unity.Programs.Abstract
         protected async Task<RequestResult<string>> SignAndSendTransaction(TransactionInstruction instruction, PublicKey feePayer, 
             Func<byte[], PublicKey, byte[]> signingCallback, Commitment commitment = Commitment.Finalized)
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
+           var latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
             TransactionBuilder tb = new TransactionBuilder();
             tb.AddInstruction(instruction);
             tb.SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash);

--- a/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
+++ b/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
@@ -57,9 +57,7 @@ namespace Solana.Unity.Programs.Abstract
             TransactionBuilder tb = new TransactionBuilder();
             tb.AddInstruction(instruction);
 
-            var recentHash = await RpcClient.GetRecentBlockHashAsync();
-
-            tb.SetRecentBlockHash(recentHash.Result.Value.Blockhash);
+            tb.SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
             tb.SetFeePayer(feePayer);
 
             var wireFmt = tb.CompileMessage();

--- a/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
+++ b/src/Solana.Unity.Programs/Abstract/TransactionalBaseClient.cs
@@ -54,10 +54,10 @@ namespace Solana.Unity.Programs.Abstract
         protected async Task<RequestResult<string>> SignAndSendTransaction(TransactionInstruction instruction, PublicKey feePayer, 
             Func<byte[], PublicKey, byte[]> signingCallback, Commitment commitment = Commitment.Finalized)
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await RpcClient.GetLatestBlockHashAsync();
             TransactionBuilder tb = new TransactionBuilder();
             tb.AddInstruction(instruction);
-
-            tb.SetRecentBlockHash(RpcClient.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
+            tb.SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash);
             tb.SetFeePayer(feePayer);
 
             var wireFmt = tb.CompileMessage();

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
@@ -289,7 +289,7 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             );
 
             //initialize tick array, open position, and increase liquidity in one transaction 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await _context.RpcClient.GetLatestBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment);
+            var latestBlockHashItem = await _context.RpcClient.GetLatestBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment);
             string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHash)

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
@@ -16,6 +16,8 @@ using Solana.Unity.Dex.Orca.Core.Program;
 using Solana.Unity.Dex.Orca.Core.Errors;
 using Solana.Unity.Dex.Orca.Core.Accounts;
 using Solana.Unity.Dex.Ticks;
+using Solana.Unity.Rpc.Core.Http;
+using Solana.Unity.Rpc.Models;
 
 namespace Solana.Unity.Dex.Test.Orca.Integration
 {
@@ -287,7 +289,8 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             );
 
             //initialize tick array, open position, and increase liquidity in one transaction 
-            string latestBlockHash = _context.RpcClient.GetLatestBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment).Result.Result.Value.Blockhash;
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await _context.RpcClient.GetLatestBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment);
+            string latestBlockHash = latestBlockHashItem.Result.Value.Blockhash;
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(openPositionParams.Accounts.Funder)

--- a/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Integration/IncreaseLiquidityTests.cs
@@ -287,9 +287,9 @@ namespace Solana.Unity.Dex.Test.Orca.Integration
             );
 
             //initialize tick array, open position, and increase liquidity in one transaction 
-            var blockHash = await _context.RpcClient.GetRecentBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment);
+            string latestBlockHash = _context.RpcClient.GetLatestBlockHashAsync(_context.WhirlpoolClient.DefaultCommitment).Result.Result.Value.Blockhash;
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHash)
                 .SetFeePayer(openPositionParams.Accounts.Funder)
                 .AddInstruction(WhirlpoolProgram.InitializeTickArray(
                     programId: _context.ProgramId,

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -302,12 +302,11 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             bool exists = await TokenUtilsTransaction.TokenAccountExists(
                 rpc, ata, commitment
             );
-            var recentHash = await rpc.GetRecentBlockHashAsync(commitment);
             if (!exists)
             {
                 TransactionBuilder builder = new();
                 builder.SetFeePayer(feePayer);
-                builder.SetRecentBlockHash(recentHash.Result.Value.Blockhash);
+                builder.SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
                 builder.AddInstruction(
                     AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
                         feePayer, owner, mintAddress, idempotent: true

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -305,7 +305,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             );
             if (!exists)
             {
-                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
+                var latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 TransactionBuilder builder = new();
                 builder.SetFeePayer(feePayer);
                 builder.SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash);

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/LiquidityTestUtils.cs
@@ -12,6 +12,7 @@ using Solana.Unity.Programs;
 using Solana.Unity.Rpc;
 using Solana.Unity.Rpc.Builders;
 using Solana.Unity.Rpc.Types;
+using Solana.Unity.Rpc.Models;
 
 namespace Solana.Unity.Dex.Test.Orca.Utils
 {
@@ -304,9 +305,10 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             );
             if (!exists)
             {
+                RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync();
                 TransactionBuilder builder = new();
                 builder.SetFeePayer(feePayer);
-                builder.SetRecentBlockHash(rpc.GetLatestBlockHashAsync().Result.Result.Value.Blockhash);
+                builder.SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash);
                 builder.AddInstruction(
                     AssociatedTokenAccountProgram.CreateAssociatedTokenAccount(
                         feePayer, owner, mintAddress, idempotent: true

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
@@ -45,7 +45,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             mintAccount = (mintAccount == null) ? new Account() : mintAccount;
             Account ownerAccount = authority;
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
@@ -85,7 +85,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
@@ -131,7 +131,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(fromAccount)
@@ -179,7 +179,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Approve(
@@ -211,7 +211,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authorityAccount)
                 .AddInstruction(TokenProgram.SetAuthority(
@@ -246,7 +246,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)
@@ -279,7 +279,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            var latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
                 .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ctx.WalletPubKey)
@@ -351,7 +351,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 balance = (await rpc.GetTokenBalanceByOwnerAsync(
                     authority.PublicKey, mint)).Result.Value.AmountUlong;
             }
-            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync(commitment: Commitment.Finalized);
+            var latestBlockHashItem = await rpc.GetLatestBlockHashAsync(commitment: Commitment.Finalized);
             TransactionBuilder txb = new();
             txb
                 .SetFeePayer(authority)

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
@@ -45,8 +45,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             mintAccount = (mintAccount == null) ? new Account() : mintAccount;
             Account ownerAccount = authority;
 
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: ownerAccount.PublicKey,
@@ -85,9 +84,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: ownerAccount,
@@ -131,9 +129,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.CreateAccount(    //create account 
                     fromAccount: fromAccount,
@@ -179,9 +176,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
-            
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Approve(
                     source: tokenAccount,
@@ -212,9 +207,7 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
-
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(authorityAccount)
                 .AddInstruction(TokenProgram.SetAuthority(
                     account: tokenAccount, 
@@ -248,9 +241,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)
                 .AddInstruction(TokenProgram.MintTo(
                     mint,
@@ -281,9 +273,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            var blockHash = await ctx.RpcClient.GetRecentBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash)
+                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
                 .SetFeePayer(ctx.WalletPubKey)
                 .AddInstruction(
                     TokenProgram.Transfer(
@@ -353,11 +344,10 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 balance = (await rpc.GetTokenBalanceByOwnerAsync(
                     authority.PublicKey, mint)).Result.Value.AmountUlong;
             }
-            var blockHash = await rpc.GetRecentBlockHashAsync(commitment: Commitment.Finalized);
             TransactionBuilder txb = new();
             txb
                 .SetFeePayer(authority)
-                .SetRecentBlockHash(blockHash.Result.Value.Blockhash);
+                .SetRecentBlockHash(rpc.GetLatestBlockHashAsync(commitment: Commitment.Finalized).Result.Result.Value.Blockhash);
             if (balance > 0)
             {
                 // Send the balance to a random ATA, close fails if balance is not 0 for not native tokens

--- a/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/Utils/TokenUtils.cs
@@ -45,7 +45,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             mintAccount = (mintAccount == null) ? new Account() : mintAccount;
             Account ownerAccount = authority;
 
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authority)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: ownerAccount.PublicKey,
@@ -84,8 +85,9 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(SystemProgram.CreateAccount(
                     fromAccount: ownerAccount,
@@ -129,8 +131,9 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             ulong minBalanceForExemption =
                 (await ctx.RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.TokenAccountDataSize)).Result;
 
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(fromAccount)
                 .AddInstruction(SystemProgram.CreateAccount(    //create account 
                     fromAccount: fromAccount,
@@ -176,7 +179,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ownerAccount)
                 .AddInstruction(TokenProgram.Approve(
                     source: tokenAccount,
@@ -207,7 +211,8 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
-            byte[] tx = new TransactionBuilder().SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync();
+            byte[] tx = new TransactionBuilder().SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(authorityAccount)
                 .AddInstruction(TokenProgram.SetAuthority(
                     account: tokenAccount, 
@@ -241,8 +246,9 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(feePayer.PublicKey)
                 .AddInstruction(TokenProgram.MintTo(
                     mint,
@@ -273,8 +279,9 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
             Commitment commitment = Commitment.Finalized
         )
         {
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await ctx.RpcClient.GetLatestBlockHashAsync(commitment);
             byte[] tx = new TransactionBuilder()
-                .SetRecentBlockHash(ctx.RpcClient.GetLatestBlockHashAsync(commitment).Result.Result.Value.Blockhash)
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash)
                 .SetFeePayer(ctx.WalletPubKey)
                 .AddInstruction(
                     TokenProgram.Transfer(
@@ -344,10 +351,11 @@ namespace Solana.Unity.Dex.Test.Orca.Utils
                 balance = (await rpc.GetTokenBalanceByOwnerAsync(
                     authority.PublicKey, mint)).Result.Value.AmountUlong;
             }
+            RequestResult<Solana.Unity.Rpc.Messages.ResponseValue<LatestBlockHash>> latestBlockHashItem = await rpc.GetLatestBlockHashAsync(commitment: Commitment.Finalized);
             TransactionBuilder txb = new();
             txb
                 .SetFeePayer(authority)
-                .SetRecentBlockHash(rpc.GetLatestBlockHashAsync(commitment: Commitment.Finalized).Result.Result.Value.Blockhash);
+                .SetRecentBlockHash(latestBlockHashItem.Result.Value.Blockhash);
             if (balance > 0)
             {
                 // Send the balance to a random ATA, close fails if balance is not 0 for not native tokens


### PR DESCRIPTION
## Updated GetRecentBlockHash to GetLatestBlockHash instances on the Soana RPC Client. Included core code and tests, but left interface-instances for convenience.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No |  |

## Problem

GetRecentBlockHash is deprecated and some Nodes do not support this call anymore (ie Helius)


## Solution

Replaced all the calls with GetLatestBlockHash() which is the advised RPC Call.
