### PR TITLE
fix: streaming rpc

### DIFF
--- a/src/Solana.Unity.Rpc/ClientFactory.cs
+++ b/src/Solana.Unity.Rpc/ClientFactory.cs
@@ -1,3 +1,4 @@
+using NativeWebSocket;
 using Solana.Unity.Rpc.Utilities;
 using System.Net.Http;
 using System.Net.WebSockets;
@@ -161,6 +162,20 @@ namespace Solana.Unity.Rpc
             };
             return GetStreamingClient(url, logger);
         }
+        
+        public static IStreamingRpcClient GetStreamingClient(
+            Cluster cluster,
+            IWebSocket socket)
+        {
+            var url = cluster switch
+            {
+                Cluster.DevNet => StreamingRpcDevNet,
+                Cluster.TestNet => StreamingRpcTestNet,
+                Cluster.LocalNet => StreamingRpcLocalNet,
+                _ => StreamingRpcMainNet,
+            };
+            return GetStreamingClient(url, null, socket, null);
+        }
 
         /// <summary>
         /// Instantiate a streaming client.
@@ -169,7 +184,7 @@ namespace Solana.Unity.Rpc
         /// <param name="logger">The logger.</param>
         /// <param name="clientWebSocket">A ClientWebSocket instance. If null, a new instance will be created.</param>
         /// <returns>The streaming client.</returns>
-        public static IStreamingRpcClient GetStreamingClient(string url, object logger = null, ClientWebSocket clientWebSocket = null)
+        public static IStreamingRpcClient GetStreamingClient(string url, object logger = null, IWebSocket socket = null, ClientWebSocket clientWebSocket = null)
         {
             return new SolanaStreamingRpcClient(url, logger, null, clientWebSocket);
         }

--- a/src/Solana.Unity.Rpc/Core/Sockets/WebSocketWrapper.cs
+++ b/src/Solana.Unity.Rpc/Core/Sockets/WebSocketWrapper.cs
@@ -45,6 +45,10 @@ namespace Solana.Unity.Rpc.Core.Sockets
             webSocket = WebSocket.Create(uri.AbsoluteUri);
             webSocket.OnOpen += () =>
             {
+                MainThreadUtil.Run(() =>
+                {
+                    _webSocketConnectionTask.TrySetResult(true);
+                });
                 _webSocketConnectionTask.TrySetResult(true);
                 webSocket.OnMessage += MessageReceived;
                 ConnectionStateChangedEvent?.Invoke(this, State);

--- a/src/Solana.Unity.Rpc/SolanaStreamingRpcClient.cs
+++ b/src/Solana.Unity.Rpc/SolanaStreamingRpcClient.cs
@@ -60,6 +60,7 @@ namespace Solana.Unity.Rpc
             };
         }
 
+
         /// <summary>
         /// Try Reconnect to the server and reopening the confirmed subscription.
         /// </summary>


### PR DESCRIPTION
# Description

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | - |

## Problem

- Under caertain circumstances, the main thread was locked on `connect_async` and `disconnect_async`
- Unable to use a custom IWebsocket implementation

## Solution

- Fixed awaiter and async
- Added an overload method on `ClientFactory.GetStreamingClient` that allow to pass an `IWebsocket` instance