### PR TITLE
Migrate to official BouncyCastle.Cryptography

### DIFF
--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenQuantity.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenQuantity.cs
@@ -1,5 +1,6 @@
 ﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -74,9 +75,9 @@ namespace Solana.Unity.Extensions
         public override string ToString()
         {
             if (Symbol == TokenName)
-                return $"{QuantityDecimal} {Symbol}";
+                return $"{QuantityDecimal.ToString(CultureInfo.InvariantCulture)} {Symbol}";
             else
-                return $"{QuantityDecimal} {Symbol} ({TokenName})";
+                return $"{QuantityDecimal.ToString(CultureInfo.InvariantCulture)} {Symbol} ({TokenName})";
         }
 
         /// <summary>

--- a/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletBalance.cs
+++ b/src/Solana.Unity.Extensions/Models/TokenWallet/TokenWalletBalance.cs
@@ -1,5 +1,6 @@
 ﻿using Solana.Unity.Extensions.Models.TokenMint;
 using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -50,9 +51,9 @@ namespace Solana.Unity.Extensions
         public override string ToString()
         {
             if (Symbol == TokenName)
-                return $"{QuantityDecimal} {Symbol}";
+                return $"{QuantityDecimal.ToString(CultureInfo.InvariantCulture)} {Symbol}";
             else
-                return $"{QuantityDecimal} {Symbol} ({TokenName})";
+                return $"{QuantityDecimal.ToString(CultureInfo.InvariantCulture)} {Symbol} ({TokenName})";
         }
 
         /// <summary>

--- a/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
+++ b/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.1" />
     <PackageReference Include="Chaos.NaCl.Standard" Version="1.0.*" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.*" />
     <PackageReference Include="IsExternalInit" Version="1.0.*" PrivateAssets="all" />
     <PackageReference Include="IndexRange" Version="1.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*"  PrivateAssets="all" />

--- a/src/Solana.Unity.Wallet/Bip39/Mnemonic.cs
+++ b/src/Solana.Unity.Wallet/Bip39/Mnemonic.cs
@@ -197,7 +197,7 @@ namespace Solana.Unity.Wallet.Bip39
         {
             Pkcs5S2ParametersGenerator gen = new(new Sha512Digest());
             gen.Init(password, salt, 2048);
-            return ((KeyParameter)gen.GenerateDerivedParameters(512)).GetKey();
+            return ((KeyParameter)gen.GenerateDerivedMacParameters(512)).GetKey();
         }
 
         /// <summary>

--- a/src/Solana.Unity.Wallet/Solana.Unity.Wallet.csproj
+++ b/src/Solana.Unity.Wallet/Solana.Unity.Wallet.csproj
@@ -11,8 +11,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Solana.Unity.Wallet.Test</_Parameter1>
     </AssemblyAttribute>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.1" />
     <PackageReference Include="Chaos.NaCl.Standard" Version="1.0.*" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.*" />
     <PackageReference Include="System.Memory" Version="4.5.*"/>
     <PackageReference Include="IndexRange" Version="1.0.*"/>
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.*" />


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| **Draft** | **Refactor**| ? | [Link](<Issue link here>) |

## Problem

`Solana.Unity-Core` relies on a deprecated unofficial fork of the BouncyCastle cryptography library, `Portable.BouncyCastle`, which hasn't been updated for ~5 years.

There're 3 vulnerability found in the original version of the old [BouncyCastle library](https://www.nuget.org/packages/BouncyCastle/1.8.9):
<img width="1776" height="1090" alt="Screenshot 2025-09-02 - QkjrjxtO@2x" src="https://github.com/user-attachments/assets/f873761a-1dfe-4bb3-9486-beabec18ea74" />

In addition to the potential security risk, it introduces a dependency conflict in Unity with third-party packages that use the official BouncyCastle library.
<img width="1594" height="332" alt="Screenshot 2025-09-02 - cqYiHwVH@2x" src="https://github.com/user-attachments/assets/5a261dc7-0a80-4f52-aee6-ee3cdb5ab734" />

## Solution

Upgrade to the official library, `BouncyCastle.Cryptography`, which is now compatible with .NET Standard, meaning it works in Unity.

## Other changes (e.g. bug fixes, small refactors)

- Minor culture conversion fixes in unit tests

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New dependencies**:

- `BouncyCastle.Cryptography`
